### PR TITLE
Change UserID type in TokenResponse, use comma-separated scopes, bump user-agent to v1.0.1

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -19,7 +19,7 @@ type TokenResponse struct {
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
 	ExpiresIn   int64  `json:"expires_in,omitempty"`
-	UserID      string `json:"user_id,omitempty"`
+	UserID      int64  `json:"user_id,omitempty"`
 }
 
 // LongLivedTokenResponse represents the response from long-lived token conversion endpoint.
@@ -59,7 +59,7 @@ func (c *Client) GetAuthURL(scopes []string) string {
 	params := url.Values{
 		"client_id":     {c.config.ClientID},
 		"redirect_uri":  {c.config.RedirectURI},
-		"scope":         {strings.Join(scopes, " ")}, // Use space-separated scopes
+		"scope":         {strings.Join(scopes, ",")}, // Use comma-separated scopes
 		"response_type": {"code"},
 		"state":         {state},
 	}
@@ -113,7 +113,7 @@ func (c *Client) ExchangeCodeForToken(ctx context.Context, code string) error {
 		AccessToken: tokenResp.AccessToken,
 		TokenType:   tokenResp.TokenType,
 		ExpiresAt:   expiresAt,
-		UserID:      tokenResp.UserID,
+		UserID:      fmt.Sprintf("%d", tokenResp.UserID),
 		CreatedAt:   now,
 	}
 
@@ -127,7 +127,7 @@ func (c *Client) ExchangeCodeForToken(ctx context.Context, code string) error {
 	// Log successful authentication if logger is available
 	if c.config.Logger != nil {
 		c.config.Logger.Info("Successfully exchanged authorization code for access token",
-			"user_id", tokenResp.UserID,
+			"user_id", fmt.Sprintf("%d", tokenResp.UserID),
 			"token_type", tokenResp.TokenType,
 			"expires_at", expiresAt)
 	}

--- a/client.go
+++ b/client.go
@@ -245,7 +245,7 @@ func NewConfig() *Config {
 			BackoffFactor: 2.0,
 		},
 		BaseURL:   "https://graph.threads.net",
-		UserAgent: "threads-go/1.0.0",
+		UserAgent: "threads-go/1.0.1",
 		Debug:     false,
 	}
 }
@@ -435,7 +435,7 @@ func (c *Config) SetDefaults() {
 	}
 
 	if c.UserAgent == "" {
-		c.UserAgent = "threads-go/1.0.0"
+		c.UserAgent = "threads-go/1.0.1"
 	}
 }
 

--- a/constants.go
+++ b/constants.go
@@ -31,7 +31,7 @@ const (
 
 	// HTTP client defaults
 	DefaultHTTPTimeout = 30 * time.Second // Default HTTP request timeout
-	DefaultUserAgent   = "threads-go/1.0.0"
+	DefaultUserAgent   = "threads-go/1.0.1"
 )
 
 // API Endpoints

--- a/http_client.go
+++ b/http_client.go
@@ -64,7 +64,7 @@ func NewHTTPClient(config *Config, rateLimiter *RateLimiter) *HTTPClient {
 		retryConfig: config.RetryConfig,
 		rateLimiter: rateLimiter,
 		baseURL:     "https://graph.threads.net",
-		userAgent:   "threads-go-client/1.0",
+		userAgent:   "threads-go/1.0.1",
 	}
 }
 


### PR DESCRIPTION
- auth.go: switch TokenResponse.UserID from string to int64; format back to string with fmt.Sprintf; use commas to join OAuth scopes
- client.go & constants.go: update default and fallback UserAgent from “threads-go/1.0.0” to “threads-go/1.0.1”
- http_client.go: update internal user-agent header to “threads-go/1.0.1”