### PR TITLE
feat: add GetContainerStatus and spoiler/text attachment features 

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -9,7 +9,9 @@ import "time"
 // API Limits
 const (
 	// Text limits
-	MaxTextLength = 500 // Maximum characters for post text
+	MaxTextLength           = 500   // Maximum characters for post text
+	MaxTextAttachmentLength = 10000 // Maximum characters for text attachment plaintext
+	MaxTextEntities         = 10    // Maximum text spoiler entities per post
 
 	// Pagination limits
 	MaxPostsPerRequest = 100 // Maximum posts per API request
@@ -18,10 +20,6 @@ const (
 	// Carousel limits
 	MinCarouselItems = 2  // Minimum items in a carousel
 	MaxCarouselItems = 20 // Maximum items in a carousel
-
-	// Video processing
-	VideoProcessingPollInterval = 10 * time.Second // How often to check video processing status
-	VideoProcessingMaxAttempts  = 30               // Maximum attempts to check video status
 
 	// Reply processing
 	ReplyPublishDelay = 10 * time.Second // Recommended delay before publishing reply
@@ -70,6 +68,10 @@ const (
 	ContainerStatusPublished  = "PUBLISHED"
 	ContainerStatusError      = "ERROR"
 	ContainerStatusExpired    = "EXPIRED"
+
+	// Container polling configuration
+	DefaultContainerPollMaxAttempts = 30              // Maximum number of polling attempts
+	DefaultContainerPollInterval    = 1 * time.Second // Interval between polling attempts
 )
 
 // Media Types

--- a/container_builder.go
+++ b/container_builder.go
@@ -155,6 +155,41 @@ func (b *ContainerBuilder) SetIsCarouselItem(isCarouselItem bool) *ContainerBuil
 	return b
 }
 
+// SetTextEntities adds text spoiler entities
+// Marks specific text ranges as spoilers using offset and length
+// Max 10 entities per post
+func (b *ContainerBuilder) SetTextEntities(entities []TextEntity) *ContainerBuilder {
+	if len(entities) > 0 {
+		entitiesJSON, err := json.Marshal(entities)
+		if err == nil {
+			b.params.Set("text_entities", string(entitiesJSON))
+		}
+	}
+	return b
+}
+
+// SetIsSpoilerMedia marks media (IMAGE, VIDEO, CAROUSEL) as spoilers
+// For CAROUSEL media type, this marks ALL media in the carousel as spoilers
+func (b *ContainerBuilder) SetIsSpoilerMedia(isSpoilerMedia bool) *ContainerBuilder {
+	if isSpoilerMedia {
+		b.params.Set("is_spoiler_media", "true")
+	}
+	return b
+}
+
+// SetTextAttachment adds a text attachment to the post
+// Can only be used with TEXT-only posts (not with polls or other media)
+// Max 10,000 characters in the plaintext field
+func (b *ContainerBuilder) SetTextAttachment(textAttachment *TextAttachment) *ContainerBuilder {
+	if textAttachment != nil {
+		attachmentJSON, err := json.Marshal(textAttachment)
+		if err == nil {
+			b.params.Set("text_attachment", string(attachmentJSON))
+		}
+	}
+	return b
+}
+
 // Build returns the built parameters
 func (b *ContainerBuilder) Build() url.Values {
 	return b.params

--- a/interfaces.go
+++ b/interfaces.go
@@ -71,6 +71,9 @@ type PostCreator interface {
 
 	// CreateMediaContainer creates a media container for carousel items
 	CreateMediaContainer(ctx context.Context, mediaType, mediaURL, altText string) (ContainerID, error)
+
+	// GetContainerStatus retrieves the status of a media container
+	GetContainerStatus(ctx context.Context, containerID ContainerID) (*ContainerStatus, error)
 }
 
 // PostReader handles post retrieval operations

--- a/posts_create.go
+++ b/posts_create.go
@@ -295,7 +295,9 @@ func (c *Client) createTextContainer(ctx context.Context, content *TextPostConte
 		SetReplyTo(content.ReplyTo).
 		SetTopicTag(content.TopicTag).
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
-		SetLocationID(content.LocationID)
+		SetLocationID(content.LocationID).
+		SetTextEntities(content.TextEntities).
+		SetTextAttachment(content.TextAttachment)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -316,7 +318,9 @@ func (c *Client) createImageContainer(ctx context.Context, content *ImagePostCon
 		SetReplyTo(content.ReplyTo).
 		SetTopicTag(content.TopicTag).
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
-		SetLocationID(content.LocationID)
+		SetLocationID(content.LocationID).
+		SetTextEntities(content.TextEntities).
+		SetIsSpoilerMedia(content.IsSpoilerMedia)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -337,7 +341,9 @@ func (c *Client) createVideoContainer(ctx context.Context, content *VideoPostCon
 		SetReplyTo(content.ReplyTo).
 		SetTopicTag(content.TopicTag).
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
-		SetLocationID(content.LocationID)
+		SetLocationID(content.LocationID).
+		SetTextEntities(content.TextEntities).
+		SetIsSpoilerMedia(content.IsSpoilerMedia)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -362,7 +368,9 @@ func (c *Client) createCarouselContainer(ctx context.Context, content *CarouselP
 		SetReplyTo(content.ReplyTo).
 		SetTopicTag(content.TopicTag).
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
-		SetLocationID(content.LocationID)
+		SetLocationID(content.LocationID).
+		SetTextEntities(content.TextEntities).
+		SetIsSpoilerMedia(content.IsSpoilerMedia)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -384,7 +392,9 @@ func (c *Client) createAndPublishTextPostDirectly(ctx context.Context, content *
 		SetReplyTo(content.ReplyTo).
 		SetTopicTag(content.TopicTag).
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
-		SetLocationID(content.LocationID)
+		SetLocationID(content.LocationID).
+		SetTextEntities(content.TextEntities).
+		SetTextAttachment(content.TextAttachment)
 
 	// Get user ID from token info
 	userID := c.getUserID()

--- a/posts_create.go
+++ b/posts_create.go
@@ -36,6 +36,11 @@ func (c *Client) CreateTextPost(ctx context.Context, content *TextPostContent) (
 		return nil, fmt.Errorf("failed to create text container: %w", err)
 	}
 
+	// Wait for container to be ready
+	if err := c.waitForContainerReady(ctx, ContainerID(containerID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval); err != nil {
+		return nil, fmt.Errorf("container not ready for publishing: %w", err)
+	}
+
 	// Publish the container
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
@@ -65,6 +70,11 @@ func (c *Client) CreateImagePost(ctx context.Context, content *ImagePostContent)
 	containerID, err := c.createImageContainer(ctx, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create image container: %w", err)
+	}
+
+	// Wait for container to be ready
+	if err := c.waitForContainerReady(ctx, ContainerID(containerID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval); err != nil {
+		return nil, fmt.Errorf("container not ready for publishing: %w", err)
 	}
 
 	// Publish the container
@@ -98,6 +108,11 @@ func (c *Client) CreateVideoPost(ctx context.Context, content *VideoPostContent)
 		return nil, fmt.Errorf("failed to create video container: %w", err)
 	}
 
+	// Wait for container to be ready
+	if err := c.waitForContainerReady(ctx, ContainerID(containerID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval); err != nil {
+		return nil, fmt.Errorf("container not ready for publishing: %w", err)
+	}
+
 	// Publish the container
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
@@ -127,6 +142,11 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 	containerID, err := c.createCarouselContainer(ctx, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create carousel container: %w", err)
+	}
+
+	// Wait for container to be ready
+	if err := c.waitForContainerReady(ctx, ContainerID(containerID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval); err != nil {
+		return nil, fmt.Errorf("container not ready for publishing: %w", err)
 	}
 
 	// Publish the container
@@ -329,16 +349,6 @@ func (c *Client) createVideoContainer(ctx context.Context, content *VideoPostCon
 		return "", err
 	}
 
-	// Videos need processing time - wait for container to be ready
-	if c.config.Logger != nil {
-		c.config.Logger.Info("Video container created, waiting for processing", "container_id", containerID)
-	}
-
-	// Wait for video processing to complete
-	if err := c.waitForContainerProcessing(ctx, containerID); err != nil {
-		return "", fmt.Errorf("video processing failed: %w", err)
-	}
-
 	return containerID, nil
 }
 
@@ -488,122 +498,86 @@ func (c *Client) publishContainer(ctx context.Context, containerID string) (*Pos
 	return c.GetPost(ctx, ConvertToPostID(publishResp.ID))
 }
 
-// waitForContainerProcessing waits for a video container to finish processing
-func (c *Client) waitForContainerProcessing(ctx context.Context, containerID string) error {
-	if c.config.Logger != nil {
-		c.config.Logger.Info("Waiting for video container processing", "container_id", containerID)
+// GetContainerStatus retrieves the status of a media container
+// This is useful for checking if a video or image container has finished processing
+// before attempting to publish it. Returns container status information including:
+// - ID: The container ID
+// - Status: Current status (IN_PROGRESS, FINISHED, PUBLISHED, ERROR, EXPIRED)
+// - ErrorMessage: Error details if status is ERROR
+func (c *Client) GetContainerStatus(ctx context.Context, containerID ContainerID) (*ContainerStatus, error) {
+	if !containerID.Valid() {
+		return nil, NewValidationError(400, ErrEmptyContainerID, "Cannot check status without container ID", "container_id")
 	}
 
-	for attempt := 1; attempt <= VideoProcessingMaxAttempts; attempt++ {
-		// Check for context cancellation
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	// Ensure we have a valid token
+	if err := c.EnsureValidToken(ctx); err != nil {
+		return nil, err
+	}
 
-		// Check container status
-		params := url.Values{
-			"fields": {ContainerStatusFields},
-		}
+	// Build request parameters with container status fields
+	params := url.Values{
+		"fields": {ContainerStatusFields},
+	}
 
-		path := fmt.Sprintf("/%s", containerID)
-		resp, err := c.httpClient.GET(path, params, c.getAccessTokenSafe())
+	// Make API call to get container status
+	path := fmt.Sprintf("/%s", containerID.String())
+	resp, err := c.httpClient.GET(path, params, c.getAccessTokenSafe())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container status: %w", err)
+	}
 
+	if resp.StatusCode != 200 {
+		return nil, c.handleAPIError(resp)
+	}
+
+	// Parse response
+	var status ContainerStatus
+	if err := safeJSONUnmarshal(resp.Body, &status, "container status response", resp.RequestID); err != nil {
+		return nil, err
+	}
+
+	// Validate response
+	if status.ID == "" {
+		return nil, NewAPIError(resp.StatusCode, "Container ID not returned", "API response missing container ID", resp.RequestID)
+	}
+
+	if status.Status == "" {
+		return nil, NewAPIError(resp.StatusCode, "Container status not returned", "API response missing container status", resp.RequestID)
+	}
+
+	return &status, nil
+}
+
+// waitForContainerReady polls the container status until it's ready to be published
+// Returns an error if the container fails or times out
+func (c *Client) waitForContainerReady(ctx context.Context, containerID ContainerID, maxAttempts int, pollInterval time.Duration) error {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		status, err := c.GetContainerStatus(ctx, containerID)
 		if err != nil {
-			if c.config.Logger != nil {
-				c.config.Logger.Warn("Failed to check container status", "container_id", containerID, "attempt", attempt, "error", err.Error())
-			}
-
-			if attempt < VideoProcessingMaxAttempts {
-				time.Sleep(VideoProcessingPollInterval)
-				continue
-			}
-			return fmt.Errorf("container status check failed after %d attempts: %w", VideoProcessingMaxAttempts, err)
+			return fmt.Errorf("failed to check container status: %w", err)
 		}
 
-		if resp.StatusCode != 200 {
-			if c.config.Logger != nil {
-				c.config.Logger.Warn("Container status check returned non-200", "container_id", containerID, "status_code", resp.StatusCode, "attempt", attempt)
-			}
-
-			if attempt < VideoProcessingMaxAttempts {
-				time.Sleep(VideoProcessingPollInterval)
-				continue
-			}
-			return NewAPIError(resp.StatusCode, "Container status check failed", string(resp.Body), "")
-		}
-
-		// Parse response to check status
-		var statusResp struct {
-			ID           string `json:"id"`
-			Status       string `json:"status"`
-			ErrorMessage string `json:"error_message,omitempty"`
-		}
-
-		if err := json.Unmarshal(resp.Body, &statusResp); err != nil {
-			if c.config.Logger != nil {
-				c.config.Logger.Warn("Failed to parse container status response", "container_id", containerID, "attempt", attempt, "error", err.Error())
-			}
-
-			if attempt < VideoProcessingMaxAttempts {
-				time.Sleep(VideoProcessingPollInterval)
-				continue
-			}
-			return fmt.Errorf("failed to parse container status response: %w", err)
-		}
-
-		if c.config.Logger != nil {
-			c.config.Logger.Info("Container status check", "container_id", containerID, "status", statusResp.Status, "attempt", attempt)
-		}
-
-		// Check status
-		switch statusResp.Status {
+		switch status.Status {
 		case ContainerStatusFinished:
-			if c.config.Logger != nil {
-				c.config.Logger.Info("Video container processing completed", "container_id", containerID, "attempts", attempt)
-			}
+			// Container is ready to be published
 			return nil
-
-		case ContainerStatusPublished:
-			if c.config.Logger != nil {
-				c.config.Logger.Info("Video container already published", "container_id", containerID, "attempts", attempt)
-			}
-			return nil
-
-		case ContainerStatusInProgress:
-			if c.config.Logger != nil {
-				c.config.Logger.Info("Video container still processing", "container_id", containerID, "attempt", attempt)
-			}
-			if attempt < VideoProcessingMaxAttempts {
-				time.Sleep(VideoProcessingPollInterval)
-				continue
-			}
-			return NewAPIError(408, "Video processing timeout", fmt.Sprintf("Container %s is still processing after %d minutes", containerID, VideoProcessingMaxAttempts), "")
-
 		case ContainerStatusError:
-			errorMsg := "Unknown error"
-			if statusResp.ErrorMessage != "" {
-				errorMsg = statusResp.ErrorMessage
+			if status.ErrorMessage != "" {
+				return fmt.Errorf("container processing failed: %s", status.ErrorMessage)
 			}
-			return NewAPIError(500, "Video processing failed", fmt.Sprintf("Container %s failed to process: %s", containerID, errorMsg), "")
-
+			return fmt.Errorf("container processing failed with error status")
 		case ContainerStatusExpired:
-			return NewAPIError(410, "Container expired", fmt.Sprintf("Container %s was not published within 24 hours and has expired", containerID), "")
-
+			return fmt.Errorf("container expired before it could be published")
+		case ContainerStatusInProgress, ContainerStatusPublished:
+			// Still processing or already published, wait and retry
+			time.Sleep(pollInterval)
+			continue
 		default:
-			// Unknown status, continue waiting
-			if c.config.Logger != nil {
-				c.config.Logger.Warn("Unknown container status", "container_id", containerID, "status", statusResp.Status, "attempt", attempt)
-			}
-			if attempt < VideoProcessingMaxAttempts {
-				time.Sleep(VideoProcessingPollInterval)
-				continue
-			}
-			return NewAPIError(500, "Unknown container status", fmt.Sprintf("Container %s has unknown status: %s", containerID, statusResp.Status), "")
+			// Unknown status, wait and retry
+			time.Sleep(pollInterval)
+			continue
 		}
 	}
 
-	// This should never be reached due to the logic above, but just in case
-	return NewAPIError(408, "Video processing timeout", fmt.Sprintf("Container %s processing timed out after %d attempts", containerID, VideoProcessingMaxAttempts), "")
+	return fmt.Errorf("timeout waiting for container to be ready after %d attempts", maxAttempts)
 }

--- a/posts_validation.go
+++ b/posts_validation.go
@@ -18,6 +18,35 @@ func (c *Client) ValidateTextPostContent(content *TextPostContent) error {
 		return err
 	}
 
+	// Validate text entities (spoilers) if present
+	if err := validator.ValidateTextEntities(content.TextEntities); err != nil {
+		return err
+	}
+
+	// Validate text attachment if present
+	if err := validator.ValidateTextAttachment(content.TextAttachment); err != nil {
+		return err
+	}
+
+	// Text attachment can only be used with TEXT-only posts
+	if content.TextAttachment != nil {
+		// Cannot be used with polls
+		if content.PollAttachment != nil {
+			return NewValidationError(400,
+				"Text attachment incompatible with poll",
+				"Text attachments cannot be used with polls",
+				"text_attachment")
+		}
+
+		// If main post has link_attachment, text attachment cannot have link_attachment_url
+		if content.LinkAttachment != "" && content.TextAttachment.LinkAttachmentURL != "" {
+			return NewValidationError(400,
+				"Duplicate link attachments",
+				"If the main post has a link_attachment, the text attachment cannot have a link_attachment_url",
+				"text_attachment.link_attachment_url")
+		}
+	}
+
 	// Validate topic tag if present
 	if content.TopicTag != "" {
 		if err := validator.ValidateTopicTag(content.TopicTag); err != nil {
@@ -45,6 +74,11 @@ func (c *Client) ValidateImagePostContent(content *ImagePostContent) error {
 
 	// Validate text length if present (500-character limit)
 	if err := validator.ValidateTextLength(content.Text, "Text"); err != nil {
+		return err
+	}
+
+	// Validate text entities (spoilers) if present
+	if err := validator.ValidateTextEntities(content.TextEntities); err != nil {
 		return err
 	}
 
@@ -83,6 +117,11 @@ func (c *Client) ValidateVideoPostContent(content *VideoPostContent) error {
 		return err
 	}
 
+	// Validate text entities (spoilers) if present
+	if err := validator.ValidateTextEntities(content.TextEntities); err != nil {
+		return err
+	}
+
 	// Validate video URL
 	if err := validator.ValidateMediaURL(content.VideoURL, "video"); err != nil {
 		return err
@@ -115,6 +154,11 @@ func (c *Client) ValidateCarouselPostContent(content *CarouselPostContent) error
 
 	// Validate text length if present (500-character limit)
 	if err := validator.ValidateTextLength(content.Text, "Text"); err != nil {
+		return err
+	}
+
+	// Validate text entities (spoilers) if present
+	if err := validator.ValidateTextEntities(content.TextEntities); err != nil {
 		return err
 	}
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -236,7 +236,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 		}
 
 		// Clean up - delete the test post using public API
-		time.Sleep(2 * time.Second) // Wait a bit before deletion
+		time.Sleep(1 * time.Second) // Wait a bit before deletion
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete test post %s: %v", post.ID, err)
@@ -273,7 +273,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 		t.Logf("Created image post: ID=%s, Text=%s, MediaType=%s", post.ID, post.Text, post.MediaType)
 
 		// Clean up - delete the test post
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete image post %s: %v", post.ID, err)
@@ -312,7 +312,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 		t.Logf("Created video post: ID=%s, Text=%s, MediaType=%s", post.ID, post.Text, post.MediaType)
 
 		// Clean up - delete the test post
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete video post %s: %v", post.ID, err)
@@ -342,7 +342,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 		t.Logf("Created second media container: %s", container2)
 
 		// Wait a moment for containers to be ready
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 
 		// Create carousel post
 		content := &threads.CarouselPostContent{
@@ -367,7 +367,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 		t.Logf("Created carousel post: ID=%s, Text=%s, MediaType=%s", post.ID, post.Text, post.MediaType)
 
 		// Clean up - delete the test post
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete carousel post %s: %v", post.ID, err)
@@ -491,7 +491,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 		t.Logf("Created post with text spoiler: ID=%s, Text=%s", post.ID, post.Text)
 
 		// Clean up
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete spoiler post %s: %v", post.ID, err)
@@ -527,7 +527,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 		t.Logf("Created post with multiple spoilers: ID=%s", post.ID)
 
 		// Clean up
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete multi-spoiler post %s: %v", post.ID, err)
@@ -556,7 +556,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 		t.Logf("Created image post with media spoiler: ID=%s", post.ID)
 
 		// Clean up
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete image spoiler post %s: %v", post.ID, err)
@@ -591,7 +591,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 		t.Logf("Created post with text and media spoilers: ID=%s", post.ID)
 
 		// Clean up
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete combined spoiler post %s: %v", post.ID, err)
@@ -630,7 +630,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 		t.Logf("Created post with text attachment: ID=%s", post.ID)
 
 		// Clean up
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete text attachment post %s: %v", post.ID, err)
@@ -656,7 +656,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 		t.Logf("Created post with text attachment and link: ID=%s", post.ID)
 
 		// Clean up
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete text attachment link post %s: %v", post.ID, err)
@@ -681,7 +681,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 			return
 		}
 
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 
 		// Create carousel with all media marked as spoilers
 		content := &threads.CarouselPostContent{
@@ -699,7 +699,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 		t.Logf("Created carousel with spoiler media: ID=%s", post.ID)
 
 		// Clean up
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete carousel spoiler post %s: %v", post.ID, err)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -459,6 +459,397 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 	})
 }
 
+// TestIntegration_SpoilersAndTextAttachments tests spoilers and text attachments features
+func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
+	skipIfNoCredentials(t)
+
+	client := createTestClient(t)
+
+	t.Run("TextPostWithSpoilers", func(t *testing.T) {
+		// Test text spoilers using text_entities
+		content := &threads.TextPostContent{
+			Text: "Spoiler alert: Darth Vader is Luke's father!",
+			TextEntities: []threads.TextEntity{
+				{
+					EntityType: "SPOILER",
+					Offset:     15, // Start of "Darth Vader is Luke's father!" (after "Spoiler alert: ")
+					Length:     11, // Just cover "Darth Vader" for testing
+				},
+			},
+		}
+
+		post, err := client.CreateTextPost(context.Background(), content)
+		if err != nil {
+			t.Errorf("CreateTextPost with spoilers failed: %v", err)
+			return
+		}
+
+		if post.ID == "" {
+			t.Error("Created post should have an ID")
+		}
+
+		t.Logf("Created post with text spoiler: ID=%s, Text=%s", post.ID, post.Text)
+
+		// Clean up
+		time.Sleep(2 * time.Second)
+		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		if err != nil {
+			t.Logf("Warning: Failed to delete spoiler post %s: %v", post.ID, err)
+		} else {
+			t.Logf("Successfully deleted spoiler post %s", post.ID)
+		}
+	})
+
+	t.Run("TextPostWithMultipleSpoilers", func(t *testing.T) {
+		// Test multiple text spoilers
+		content := &threads.TextPostContent{
+			Text: "Two spoilers: Han dies and Rey is a Palpatine!",
+			TextEntities: []threads.TextEntity{
+				{
+					EntityType: "SPOILER",
+					Offset:     14, // "Han dies"
+					Length:     8,
+				},
+				{
+					EntityType: "SPOILER",
+					Offset:     27, // "Rey is a Palpatine"
+					Length:     18,
+				},
+			},
+		}
+
+		post, err := client.CreateTextPost(context.Background(), content)
+		if err != nil {
+			t.Errorf("CreateTextPost with multiple spoilers failed: %v", err)
+			return
+		}
+
+		t.Logf("Created post with multiple spoilers: ID=%s", post.ID)
+
+		// Clean up
+		time.Sleep(2 * time.Second)
+		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		if err != nil {
+			t.Logf("Warning: Failed to delete multi-spoiler post %s: %v", post.ID, err)
+		}
+	})
+
+	t.Run("ImagePostWithMediaSpoiler", func(t *testing.T) {
+		if testImageURL1 == "" {
+			t.Skip("Skipping image spoiler test: THREADS_TEST_IMG1 not provided")
+		}
+
+		// Test media spoiler with image
+		content := &threads.ImagePostContent{
+			Text:           fmt.Sprintf("CI test image spoiler created at %s", time.Now().Format(time.RFC3339)),
+			ImageURL:       testImageURL1,
+			AltText:        "Spoiler image",
+			IsSpoilerMedia: true, // Mark the image as a spoiler
+		}
+
+		post, err := client.CreateImagePost(context.Background(), content)
+		if err != nil {
+			t.Errorf("CreateImagePost with media spoiler failed: %v", err)
+			return
+		}
+
+		t.Logf("Created image post with media spoiler: ID=%s", post.ID)
+
+		// Clean up
+		time.Sleep(2 * time.Second)
+		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		if err != nil {
+			t.Logf("Warning: Failed to delete image spoiler post %s: %v", post.ID, err)
+		}
+	})
+
+	t.Run("ImagePostWithTextAndMediaSpoilers", func(t *testing.T) {
+		if testImageURL1 == "" {
+			t.Skip("Skipping combined spoiler test: THREADS_TEST_IMG1 not provided")
+		}
+
+		// Test both text and media spoilers
+		content := &threads.ImagePostContent{
+			Text:     "Spoiler: This image reveals the ending!",
+			ImageURL: testImageURL1,
+			TextEntities: []threads.TextEntity{
+				{
+					EntityType: "SPOILER",
+					Offset:     9,  // Start of "This image reveals the ending!" (after "Spoiler: ")
+					Length:     30, // Length of "This image reveals the ending!"
+				},
+			},
+			IsSpoilerMedia: true,
+		}
+
+		post, err := client.CreateImagePost(context.Background(), content)
+		if err != nil {
+			t.Errorf("CreateImagePost with text and media spoilers failed: %v", err)
+			return
+		}
+
+		t.Logf("Created post with text and media spoilers: ID=%s", post.ID)
+
+		// Clean up
+		time.Sleep(2 * time.Second)
+		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		if err != nil {
+			t.Logf("Warning: Failed to delete combined spoiler post %s: %v", post.ID, err)
+		}
+	})
+
+	t.Run("TextPostWithTextAttachment", func(t *testing.T) {
+		// Test text attachment with styling
+		content := &threads.TextPostContent{
+			Text: fmt.Sprintf("CI test post with text attachment at %s", time.Now().Format(time.RFC3339)),
+			TextAttachment: &threads.TextAttachment{
+				Plaintext: "This is a long-form text attachment with up to 10,000 characters. " +
+					"It supports rich formatting and allows you to share detailed content beyond the 500 character limit. " +
+					"This is perfect for sharing articles, stories, or detailed explanations.",
+				TextWithStylingInfo: []threads.TextStylingInfo{
+					{
+						Offset:      0,
+						Length:      7, // "This is"
+						StylingInfo: []string{"bold"},
+					},
+					{
+						Offset:      10,
+						Length:      9, // "long-form"
+						StylingInfo: []string{"italic"},
+					},
+				},
+			},
+		}
+
+		post, err := client.CreateTextPost(context.Background(), content)
+		if err != nil {
+			t.Errorf("CreateTextPost with text attachment failed: %v", err)
+			return
+		}
+
+		t.Logf("Created post with text attachment: ID=%s", post.ID)
+
+		// Clean up
+		time.Sleep(2 * time.Second)
+		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		if err != nil {
+			t.Logf("Warning: Failed to delete text attachment post %s: %v", post.ID, err)
+		}
+	})
+
+	t.Run("TextAttachmentWithLink", func(t *testing.T) {
+		// Test text attachment with link
+		content := &threads.TextPostContent{
+			Text: "Check out my detailed post with a link!",
+			TextAttachment: &threads.TextAttachment{
+				Plaintext:         "Here's a detailed explanation with additional information that couldn't fit in the main post. This text attachment includes a link for more details.",
+				LinkAttachmentURL: "https://example.com/more-info",
+			},
+		}
+
+		post, err := client.CreateTextPost(context.Background(), content)
+		if err != nil {
+			t.Errorf("CreateTextPost with text attachment link failed: %v", err)
+			return
+		}
+
+		t.Logf("Created post with text attachment and link: ID=%s", post.ID)
+
+		// Clean up
+		time.Sleep(2 * time.Second)
+		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		if err != nil {
+			t.Logf("Warning: Failed to delete text attachment link post %s: %v", post.ID, err)
+		}
+	})
+
+	t.Run("CarouselWithMediaSpoiler", func(t *testing.T) {
+		if testImageURL1 == "" || testImageURL2 == "" {
+			t.Skip("Skipping carousel spoiler test: THREADS_TEST_IMG1 or THREADS_TEST_IMG2 not provided")
+		}
+
+		// Create media containers
+		container1, err := client.CreateMediaContainer(context.Background(), "IMAGE", testImageURL1, "First carousel image")
+		if err != nil {
+			t.Errorf("Failed to create first media container: %v", err)
+			return
+		}
+
+		container2, err := client.CreateMediaContainer(context.Background(), "IMAGE", testImageURL2, "Second carousel image")
+		if err != nil {
+			t.Errorf("Failed to create second media container: %v", err)
+			return
+		}
+
+		time.Sleep(3 * time.Second)
+
+		// Create carousel with all media marked as spoilers
+		content := &threads.CarouselPostContent{
+			Text:           fmt.Sprintf("CI test carousel with spoilers at %s", time.Now().Format(time.RFC3339)),
+			Children:       []string{string(container1), string(container2)},
+			IsSpoilerMedia: true, // Marks ALL carousel media as spoilers
+		}
+
+		post, err := client.CreateCarouselPost(context.Background(), content)
+		if err != nil {
+			t.Errorf("CreateCarouselPost with spoilers failed: %v", err)
+			return
+		}
+
+		t.Logf("Created carousel with spoiler media: ID=%s", post.ID)
+
+		// Clean up
+		time.Sleep(2 * time.Second)
+		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		if err != nil {
+			t.Logf("Warning: Failed to delete carousel spoiler post %s: %v", post.ID, err)
+		}
+	})
+}
+
+// TestIntegration_ContainerStatus tests the GetContainerStatus method
+func TestIntegration_ContainerStatus(t *testing.T) {
+	skipIfNoCredentials(t)
+
+	if testImageURL1 == "" {
+		t.Skip("Skipping container status test: THREADS_TEST_IMG1 not provided")
+	}
+
+	client := createTestClient(t)
+
+	t.Run("GetContainerStatus", func(t *testing.T) {
+		// Create a media container
+		containerID, err := client.CreateMediaContainer(context.Background(), "IMAGE", testImageURL1, "Test image for container status")
+		if err != nil {
+			t.Errorf("Failed to create media container: %v", err)
+			return
+		}
+
+		t.Logf("Created media container: %s", containerID)
+
+		// Get the container status
+		status, err := client.GetContainerStatus(context.Background(), containerID)
+		if err != nil {
+			t.Errorf("GetContainerStatus failed: %v", err)
+			return
+		}
+
+		if status.ID == "" {
+			t.Error("Container status should have an ID")
+		}
+
+		if status.Status == "" {
+			t.Error("Container status should have a status field")
+		}
+
+		t.Logf("Container status: ID=%s, Status=%s, ErrorMessage=%s",
+			status.ID, status.Status, status.ErrorMessage)
+
+		// Verify status is one of the valid values
+		validStatuses := map[string]bool{
+			"IN_PROGRESS": true,
+			"FINISHED":    true,
+			"PUBLISHED":   true,
+			"ERROR":       true,
+			"EXPIRED":     true,
+		}
+
+		if !validStatuses[status.Status] {
+			t.Errorf("Invalid container status: %s", status.Status)
+		}
+	})
+}
+
+// TestIntegration_ValidationErrors tests validation for new features
+func TestIntegration_ValidationErrors(t *testing.T) {
+	skipIfNoCredentials(t)
+
+	client := createTestClient(t)
+
+	t.Run("TooManyTextEntities", func(t *testing.T) {
+		// Try to create post with more than 10 text entities (should fail validation)
+		entities := make([]threads.TextEntity, 11)
+		for i := 0; i < 11; i++ {
+			entities[i] = threads.TextEntity{
+				EntityType: "SPOILER",
+				Offset:     i * 5,
+				Length:     3,
+			}
+		}
+
+		content := &threads.TextPostContent{
+			Text:         "This post has too many spoiler entities and should fail validation",
+			TextEntities: entities,
+		}
+
+		_, err := client.CreateTextPost(context.Background(), content)
+		if err == nil {
+			t.Error("Expected validation error for too many text entities")
+		} else {
+			t.Logf("Validation error (expected): %v", err)
+		}
+	})
+
+	t.Run("TextAttachmentWithPoll", func(t *testing.T) {
+		// Try to create post with both text attachment and poll (should fail validation)
+		content := &threads.TextPostContent{
+			Text: "This should fail validation",
+			PollAttachment: &threads.PollAttachment{
+				OptionA: "Option A",
+				OptionB: "Option B",
+			},
+			TextAttachment: &threads.TextAttachment{
+				Plaintext: "This should not be allowed with a poll",
+			},
+		}
+
+		_, err := client.CreateTextPost(context.Background(), content)
+		if err == nil {
+			t.Error("Expected validation error for text attachment with poll")
+		} else {
+			t.Logf("Validation error (expected): %v", err)
+		}
+	})
+
+	t.Run("InvalidTextEntityOffset", func(t *testing.T) {
+		// Try to create post with negative offset (should fail validation)
+		content := &threads.TextPostContent{
+			Text: "This should fail validation",
+			TextEntities: []threads.TextEntity{
+				{
+					EntityType: "SPOILER",
+					Offset:     -1, // Invalid negative offset
+					Length:     5,
+				},
+			},
+		}
+
+		_, err := client.CreateTextPost(context.Background(), content)
+		if err == nil {
+			t.Error("Expected validation error for negative offset")
+		} else {
+			t.Logf("Validation error (expected): %v", err)
+		}
+	})
+
+	t.Run("EmptyTextAttachmentPlaintext", func(t *testing.T) {
+		// Try to create post with empty text attachment plaintext (should fail validation)
+		content := &threads.TextPostContent{
+			Text: "This should fail validation",
+			TextAttachment: &threads.TextAttachment{
+				Plaintext: "", // Empty plaintext is not allowed
+			},
+		}
+
+		_, err := client.CreateTextPost(context.Background(), content)
+		if err == nil {
+			t.Error("Expected validation error for empty text attachment plaintext")
+		} else {
+			t.Logf("Validation error (expected): %v", err)
+		}
+	})
+}
+
 // Helper functions
 
 // truncateString truncates strings for logging

--- a/types.go
+++ b/types.go
@@ -131,6 +131,13 @@ type TextPostContent struct {
 	// QuotedPostID makes this a quote post when provided
 	// Leave empty for regular text posts
 	QuotedPostID string `json:"quoted_post_id,omitempty"`
+	// TextEntities marks specific text ranges as spoilers
+	// Max 10 entities per post. Each entity specifies offset and length of spoiler text.
+	TextEntities []TextEntity `json:"text_entities,omitempty"`
+	// TextAttachment allows adding longer text content with styling
+	// Can only be used with TEXT-only posts (not with polls or other media types)
+	// Max 10,000 characters in plaintext field
+	TextAttachment *TextAttachment `json:"text_attachment,omitempty"`
 }
 
 // ImagePostContent represents content for image posts.
@@ -147,6 +154,11 @@ type ImagePostContent struct {
 	// QuotedPostID makes this a quote post when provided
 	// Leave empty for regular image posts
 	QuotedPostID string `json:"quoted_post_id,omitempty"`
+	// TextEntities marks specific text ranges as spoilers
+	// Max 10 entities per post. Each entity specifies offset and length of spoiler text.
+	TextEntities []TextEntity `json:"text_entities,omitempty"`
+	// IsSpoilerMedia marks the image as a spoiler
+	IsSpoilerMedia bool `json:"is_spoiler_media,omitempty"`
 }
 
 // VideoPostContent represents content for video posts.
@@ -163,6 +175,11 @@ type VideoPostContent struct {
 	// QuotedPostID makes this a quote post when provided
 	// Leave empty for regular image posts
 	QuotedPostID string `json:"quoted_post_id,omitempty"`
+	// TextEntities marks specific text ranges as spoilers
+	// Max 10 entities per post. Each entity specifies offset and length of spoiler text.
+	TextEntities []TextEntity `json:"text_entities,omitempty"`
+	// IsSpoilerMedia marks the video as a spoiler
+	IsSpoilerMedia bool `json:"is_spoiler_media,omitempty"`
 }
 
 // CarouselPostContent represents content for carousel posts.
@@ -178,6 +195,11 @@ type CarouselPostContent struct {
 	// QuotedPostID makes this a quote post when provided
 	// Leave empty for regular image posts
 	QuotedPostID string `json:"quoted_post_id,omitempty"`
+	// TextEntities marks specific text ranges as spoilers
+	// Max 10 entities per post. Each entity specifies offset and length of spoiler text.
+	TextEntities []TextEntity `json:"text_entities,omitempty"`
+	// IsSpoilerMedia marks ALL carousel media (images/videos) as spoilers
+	IsSpoilerMedia bool `json:"is_spoiler_media,omitempty"`
 }
 
 // ReplyControl defines who can reply to a post
@@ -408,4 +430,36 @@ type ChildrenData struct {
 // ChildPost represents a child post in a carousel
 type ChildPost struct {
 	ID string `json:"id"`
+}
+
+// ContainerStatus represents the status of a media container
+// Used to check processing status before publishing posts
+type ContainerStatus struct {
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+// TextEntity represents a spoiler entity within text content
+// Used to mark specific ranges of text as spoilers using offset and length
+type TextEntity struct {
+	EntityType string `json:"entity_type"` // "SPOILER" or "spoiler"
+	Offset     int    `json:"offset"`      // Starting position of the spoiler (0-indexed)
+	Length     int    `json:"length"`      // Length of the spoiler text from offset
+}
+
+// TextAttachment represents a text attachment with optional styling
+// Text attachments allow up to 10,000 characters of long-form content
+// Can only be used with TEXT-only posts (not with polls or other media)
+type TextAttachment struct {
+	Plaintext           string            `json:"plaintext"`                        // Required: The text content (max 10K chars)
+	LinkAttachmentURL   string            `json:"link_attachment_url,omitempty"`    // Optional: URL to include
+	TextWithStylingInfo []TextStylingInfo `json:"text_with_styling_info,omitempty"` // Optional: Styling information
+}
+
+// TextStylingInfo represents styling to apply to a range of text in a text attachment
+type TextStylingInfo struct {
+	Offset      int      `json:"offset"`       // Starting position for styling (0-indexed)
+	Length      int      `json:"length"`       // Length of text to style from offset
+	StylingInfo []string `json:"styling_info"` // Array of styles: "bold", "italic", "highlight", "underline", "strikethrough"
 }

--- a/validation.go
+++ b/validation.go
@@ -32,6 +32,105 @@ func (v *Validator) ValidateTextLength(text string, fieldName string) error {
 	return nil
 }
 
+// ValidateTextAttachment validates text attachment structure and content
+func (v *Validator) ValidateTextAttachment(textAttachment *TextAttachment) error {
+	if textAttachment == nil {
+		return nil // Text attachment is optional
+	}
+
+	// Validate plaintext length (required field, max 10K chars)
+	if textAttachment.Plaintext == "" {
+		return NewValidationError(400,
+			"Text attachment plaintext required",
+			"Text attachment must have a plaintext field",
+			"text_attachment.plaintext")
+	}
+
+	if len(textAttachment.Plaintext) > MaxTextAttachmentLength {
+		return NewValidationError(400,
+			"Text attachment plaintext too long",
+			fmt.Sprintf("Text attachment plaintext is limited to %d characters (currently %d)", MaxTextAttachmentLength, len(textAttachment.Plaintext)),
+			"text_attachment.plaintext")
+	}
+
+	// Validate text styling ranges don't overlap
+	if len(textAttachment.TextWithStylingInfo) > 0 {
+		if err := v.validateTextStylingRanges(textAttachment.TextWithStylingInfo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateTextStylingRanges checks that text styling ranges don't overlap
+func (v *Validator) validateTextStylingRanges(stylingInfo []TextStylingInfo) error {
+	for i := 0; i < len(stylingInfo); i++ {
+		for j := i + 1; j < len(stylingInfo); j++ {
+			// Check if ranges overlap
+			start1, end1 := stylingInfo[i].Offset, stylingInfo[i].Offset+stylingInfo[i].Length
+			start2, end2 := stylingInfo[j].Offset, stylingInfo[j].Offset+stylingInfo[j].Length
+
+			if start1 < end2 && end1 > start2 {
+				return NewValidationError(400,
+					"Overlapping text styling ranges",
+					fmt.Sprintf("Text styling ranges cannot overlap: range %d [%d,%d) overlaps with range %d [%d,%d)",
+						i, start1, end1, j, start2, end2),
+					"text_attachment.text_with_styling_info")
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateTextEntities validates text spoiler entities
+func (v *Validator) ValidateTextEntities(entities []TextEntity) error {
+	if len(entities) == 0 {
+		return nil // Optional field
+	}
+
+	// Check max limit
+	if len(entities) > MaxTextEntities {
+		return NewValidationError(400,
+			"Too many text entities",
+			fmt.Sprintf("Maximum %d text spoiler entities allowed per post (currently %d)", MaxTextEntities, len(entities)),
+			"text_entities")
+	}
+
+	// Validate each entity
+	for i, entity := range entities {
+		if entity.EntityType == "" {
+			return NewValidationError(400,
+				"Text entity missing type",
+				fmt.Sprintf("Text entity at index %d must have an entity_type", i),
+				"text_entities")
+		}
+
+		if entity.EntityType != "SPOILER" && entity.EntityType != "spoiler" {
+			return NewValidationError(400,
+				"Invalid text entity type",
+				fmt.Sprintf("Text entity at index %d has invalid type '%s' (must be 'SPOILER' or 'spoiler')", i, entity.EntityType),
+				"text_entities")
+		}
+
+		if entity.Offset < 0 {
+			return NewValidationError(400,
+				"Invalid text entity offset",
+				fmt.Sprintf("Text entity at index %d has negative offset %d", i, entity.Offset),
+				"text_entities")
+		}
+
+		if entity.Length <= 0 {
+			return NewValidationError(400,
+				"Invalid text entity length",
+				fmt.Sprintf("Text entity at index %d has non-positive length %d", i, entity.Length),
+				"text_entities")
+		}
+	}
+
+	return nil
+}
+
 // ValidateMediaURL validates media URLs for basic format and accessibility
 func (v *Validator) ValidateMediaURL(mediaURL, mediaType string) error {
 	if mediaURL == "" {


### PR DESCRIPTION
Implements new Threads API features:

1. **GetContainerStatus Method** - Check container processing status before publishing

2. **Text Spoilers** - Mark text ranges as spoilers via text_entities

3. **Media Spoilers** - Mark media as spoilers via is_spoiler_media

4. **Text Attachments** - Add up to 10K chars with optional styling and links

## Key Improvements

- Automatic container status polling prevents premature publishing errors
- Comprehensive client-side validation for all new features
- Full integration test coverage

## References

- https://developers.facebook.com/docs/threads/create-posts/spoilers
- https://developers.facebook.com/docs/threads/create-posts/text-attachments
