### PR TITLE
feat: add GIF attachment support for text posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ insights, err := client.GetAccountInsights(ctx, threads.UserID("456"), []string{
 // Search posts by keyword
 results, err := client.KeywordSearch(ctx, "golang", &threads.SearchOptions{Limit: 25})
 
-// Search posts filtered by media type (new in v1.0.3)
+// Search posts filtered by media type
 imageResults, err := client.KeywordSearch(ctx, "nature", &threads.SearchOptions{
     MediaType: threads.MediaTypeImage,  // Filter for IMAGE posts only (TEXT, IMAGE, or VIDEO)
     Limit: 25,

--- a/constants.go
+++ b/constants.go
@@ -28,7 +28,7 @@ const (
 	MinSearchTimestamp = 1688540400 // Minimum timestamp for search queries (July 5, 2023)
 
 	// Library version
-	Version = "1.0.3"
+	Version = "1.1.0"
 
 	// HTTP client defaults
 	DefaultHTTPTimeout = 30 * time.Second // Default HTTP request timeout

--- a/container_builder.go
+++ b/container_builder.go
@@ -190,6 +190,19 @@ func (b *ContainerBuilder) SetTextAttachment(textAttachment *TextAttachment) *Co
 	return b
 }
 
+// SetGIFAttachment adds a GIF attachment to the post
+// Can only be used with TEXT-only posts (not with image, video, or carousel posts)
+// Tenor is currently the only available GIF provider
+func (b *ContainerBuilder) SetGIFAttachment(gifAttachment *GIFAttachment) *ContainerBuilder {
+	if gifAttachment != nil {
+		attachmentJSON, err := json.Marshal(gifAttachment)
+		if err == nil {
+			b.params.Set("gif_attachment", string(attachmentJSON))
+		}
+	}
+	return b
+}
+
 // Build returns the built parameters
 func (b *ContainerBuilder) Build() url.Values {
 	return b.params

--- a/posts_create.go
+++ b/posts_create.go
@@ -297,7 +297,8 @@ func (c *Client) createTextContainer(ctx context.Context, content *TextPostConte
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
 		SetLocationID(content.LocationID).
 		SetTextEntities(content.TextEntities).
-		SetTextAttachment(content.TextAttachment)
+		SetTextAttachment(content.TextAttachment).
+		SetGIFAttachment(content.GIFAttachment)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -394,7 +395,8 @@ func (c *Client) createAndPublishTextPostDirectly(ctx context.Context, content *
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
 		SetLocationID(content.LocationID).
 		SetTextEntities(content.TextEntities).
-		SetTextAttachment(content.TextAttachment)
+		SetTextAttachment(content.TextAttachment).
+		SetGIFAttachment(content.GIFAttachment)
 
 	// Get user ID from token info
 	userID := c.getUserID()

--- a/posts_validation.go
+++ b/posts_validation.go
@@ -28,6 +28,11 @@ func (c *Client) ValidateTextPostContent(content *TextPostContent) error {
 		return err
 	}
 
+	// Validate GIF attachment if present
+	if err := validator.ValidateGIFAttachment(content.GIFAttachment); err != nil {
+		return err
+	}
+
 	// Text attachment can only be used with TEXT-only posts
 	if content.TextAttachment != nil {
 		// Cannot be used with polls

--- a/types.go
+++ b/types.go
@@ -138,6 +138,10 @@ type TextPostContent struct {
 	// Can only be used with TEXT-only posts (not with polls or other media types)
 	// Max 10,000 characters in plaintext field
 	TextAttachment *TextAttachment `json:"text_attachment,omitempty"`
+	// GIFAttachment allows attaching a GIF to the text post
+	// Can only be used with TEXT-only posts (not with image, video, or carousel posts)
+	// Tenor is currently the only available GIF provider
+	GIFAttachment *GIFAttachment `json:"gif_attachment,omitempty"`
 }
 
 // ImagePostContent represents content for image posts.
@@ -462,4 +466,22 @@ type TextStylingInfo struct {
 	Offset      int      `json:"offset"`       // Starting position for styling (0-indexed)
 	Length      int      `json:"length"`       // Length of text to style from offset
 	StylingInfo []string `json:"styling_info"` // Array of styles: "bold", "italic", "highlight", "underline", "strikethrough"
+}
+
+// GIFProvider represents supported GIF providers
+type GIFProvider string
+
+const (
+	// GIFProviderTenor is the Tenor GIF provider (currently the only supported provider)
+	GIFProviderTenor GIFProvider = "TENOR"
+)
+
+// GIFAttachment represents a GIF attachment for text posts
+// GIFs can only be attached to text-only posts (not image, video, or carousel posts)
+// Tenor is currently the only available GIF provider
+type GIFAttachment struct {
+	// GIFID is the ID of the GIF from the provider (e.g., Tenor API response id field)
+	GIFID string `json:"gif_id"`
+	// Provider is the GIF provider (currently only "TENOR" is supported)
+	Provider GIFProvider `json:"provider"`
 }

--- a/validation.go
+++ b/validation.go
@@ -264,6 +264,39 @@ func (v *Validator) ValidateSearchOptions(opts *SearchOptions) error {
 	return nil
 }
 
+// ValidateGIFAttachment validates GIF attachment structure and content
+func (v *Validator) ValidateGIFAttachment(gifAttachment *GIFAttachment) error {
+	if gifAttachment == nil {
+		return nil // GIF attachment is optional
+	}
+
+	// Validate GIF ID is provided
+	if strings.TrimSpace(gifAttachment.GIFID) == "" {
+		return NewValidationError(400,
+			"GIF ID required",
+			"GIF attachment must have a gif_id field",
+			"gif_attachment.gif_id")
+	}
+
+	// Validate provider is provided and valid
+	if gifAttachment.Provider == "" {
+		return NewValidationError(400,
+			"GIF provider required",
+			"GIF attachment must have a provider field",
+			"gif_attachment.provider")
+	}
+
+	// Currently only TENOR is supported
+	if gifAttachment.Provider != GIFProviderTenor {
+		return NewValidationError(400,
+			"Invalid GIF provider",
+			fmt.Sprintf("GIF provider '%s' is not supported. Currently only 'TENOR' is supported", gifAttachment.Provider),
+			"gif_attachment.provider")
+	}
+
+	return nil
+}
+
 // ConfigValidator validates client configuration
 type ConfigValidator struct{}
 


### PR DESCRIPTION
Summary
- Add support for attaching GIFs to text posts using the Threads API gif_attachment parameter. Tenor is currently the only supported GIF provider.

Notes
  - GIFs can only be attached to text-only posts (not image, video, or carousel posts)
  - Tenor is currently the only supported GIF provider per Threads API documentation

  References
  - https://developers.facebook.com/docs/threads/posts#gifs