### PR TITLE
fix: wait for child containers before creating carousel

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -341,8 +341,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 		}
 		t.Logf("Created second media container: %s", container2)
 
-		// Wait a moment for containers to be ready
-		time.Sleep(1 * time.Second)
+		// Note: No sleep needed - CreateCarouselPost waits for child containers to be ready
 
 		// Create carousel post
 		content := &threads.CarouselPostContent{
@@ -681,7 +680,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 			return
 		}
 
-		time.Sleep(1 * time.Second)
+		// Note: No sleep needed - CreateCarouselPost waits for child containers to be ready
 
 		// Create carousel with all media marked as spoilers
 		content := &threads.CarouselPostContent{


### PR DESCRIPTION
CreateCarouselPost now polls each child container until it reaches FINISHED status before creating the carousel container. This fixes flaky integration tests where the API would reject carousel creation with "Invalid Carousel Children" errors due to children not being ready yet.

Removed unnecessary time.Sleep(1 * time.Second) workarounds from integration tests since the library now handles this properly.