### PR TITLE
feat: Add January 2026 Threads API updates

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -443,3 +443,20 @@ func TestGIFAttachmentStruct(t *testing.T) {
 		t.Errorf("Expected Provider to be GIFProviderTenor, got '%s'", gif.Provider)
 	}
 }
+
+func TestSearchOptionsAuthorUsername(t *testing.T) {
+	opts := &SearchOptions{
+		AuthorUsername: "testuser",
+		SearchType:     SearchTypeTop,
+	}
+
+	if opts.AuthorUsername != "testuser" {
+		t.Errorf("Expected AuthorUsername to be 'testuser', got '%s'", opts.AuthorUsername)
+	}
+
+	// Test with @ prefix (should be stripped in search.go)
+	opts.AuthorUsername = "@testuser"
+	if opts.AuthorUsername != "@testuser" {
+		t.Errorf("Expected AuthorUsername to be '@testuser', got '%s'", opts.AuthorUsername)
+	}
+}

--- a/constants.go
+++ b/constants.go
@@ -43,7 +43,7 @@ const (
 
 // Field Sets for API requests
 const (
-	// Post fields (is_verified and profile_picture_url added December 16, 2025 for replies/mentions)
+	// Post fields
 	PostExtendedFields = "id,media_product_type,media_type,media_url,permalink,owner,username,text,timestamp,shortcode,thumbnail_url,children,is_quote_post,alt_text,link_attachment_url,has_replies,reply_audience,quoted_post,reposted_post,gif_url,is_verified,profile_picture_url"
 
 	// Ghost Post fields
@@ -53,7 +53,6 @@ const (
 	UserProfileFields = "id,username,name,threads_profile_picture_url,threads_biography,is_verified"
 
 	// Reply fields (includes additional reply-specific fields)
-	// is_verified and profile_picture_url added December 16, 2025 (only available on direct replies for conversations)
 	ReplyFields = "id,media_product_type,media_type,media_url,permalink,username,text,timestamp,shortcode,thumbnail_url,children,is_quote_post,has_replies,root_post,replied_to,is_reply,is_reply_owned_by_me,reply_audience,quoted_post,reposted_post,gif_url,alt_text,hide_status,topic_tag,is_verified,profile_picture_url"
 
 	// Container status fields
@@ -99,6 +98,6 @@ const (
 const (
 	// ErrCodeLinkLimitExceeded is returned when a post contains more than 5 unique links.
 	// This error occurs during media container creation (POST /{threads-user-id}/threads).
-	// Added December 22, 2025. Reduce the number of unique links to 5 or fewer to resolve.
+	// Reduce the number of unique links to 5 or fewer to resolve.
 	ErrCodeLinkLimitExceeded = "THREADS_API__LINK_LIMIT_EXCEEDED"
 )

--- a/search.go
+++ b/search.go
@@ -40,6 +40,14 @@ func (c *Client) KeywordSearch(ctx context.Context, query string, opts *SearchOp
 			}
 			params.Set("media_type", mediaType)
 		}
+		if opts.AuthorUsername != "" {
+			// Strip leading @ if present for convenience
+			username := strings.TrimPrefix(opts.AuthorUsername, "@")
+			if strings.TrimSpace(username) == "" {
+				return nil, NewValidationError(400, "Invalid author username", "Author username cannot be empty", "author_username")
+			}
+			params.Set("author_username", username)
+		}
 		if opts.Limit > 0 {
 			if opts.Limit > 100 {
 				return nil, NewValidationError(400, "Limit too large", "Maximum limit is 100 posts per request", "limit")

--- a/types.go
+++ b/types.go
@@ -77,11 +77,9 @@ type Post struct {
 	GhostPostExpirationTimestamp Time          `json:"ghost_post_expiration_timestamp,omitempty"`
 	// IsVerified indicates if the post author's profile is verified on Threads.
 	// Available for replies and mentions. For conversations, only available on direct replies.
-	// Added December 16, 2025.
 	IsVerified bool `json:"is_verified,omitempty"`
 	// ProfilePictureURL is the URL of the post author's profile picture on Threads.
 	// Available for replies and mentions. For conversations, only available on direct replies.
-	// Added December 16, 2025.
 	ProfilePictureURL string `json:"profile_picture_url,omitempty"`
 }
 
@@ -326,14 +324,15 @@ type RepliesOptions struct {
 
 // SearchOptions represents options for keyword and topic tag search
 type SearchOptions struct {
-	SearchType SearchType `json:"search_type,omitempty"`
-	SearchMode SearchMode `json:"search_mode,omitempty"`
-	MediaType  string     `json:"media_type,omitempty"` // Filter by media type: TEXT, IMAGE, or VIDEO
-	Limit      int        `json:"limit,omitempty"`
-	Since      int64      `json:"since,omitempty"` // Unix timestamp (must be >= 1688540400)
-	Until      int64      `json:"until,omitempty"` // Unix timestamp
-	Before     string     `json:"before,omitempty"`
-	After      string     `json:"after,omitempty"`
+	SearchType     SearchType `json:"search_type,omitempty"`
+	SearchMode     SearchMode `json:"search_mode,omitempty"`
+	MediaType      string     `json:"media_type,omitempty"`      // Filter by media type: TEXT, IMAGE, or VIDEO
+	AuthorUsername string     `json:"author_username,omitempty"` // Filter by author username (exact match, without @)
+	Limit          int        `json:"limit,omitempty"`
+	Since          int64      `json:"since,omitempty"` // Unix timestamp (must be >= 1688540400)
+	Until          int64      `json:"until,omitempty"` // Unix timestamp
+	Before         string     `json:"before,omitempty"`
+	After          string     `json:"after,omitempty"`
 }
 
 // SearchType defines the search behavior


### PR DESCRIPTION
## Summary
- Add `author_username` parameter to `SearchOptions` for filtering keyword/tag search results by author (January 20, 2026 changelog)
- Remove date-stamped comments from `types.go` and `constants.go`

## January 2026 Changelog Assessment
| Date | Item | Action |
|------|------|--------|
| Jan 20 | `author_username` search filter | Implemented |
| Jan 22 | Web Intents `tag`/`reply_control` params | N/A - Web Intents, not API client |
| Jan 26 | Webhook `is_verified`/`profile_picture_url` | N/A - no webhook types in library; existing `Post` struct already covers these fields |
| Jan 30 | `followers_count`/`follower_demographics` for non-Instagram profiles | N/A - API-side policy change, no client restriction existed |

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./... -short` passes
- [ ] Integration test with live API credentials