### PR TITLE
feat: Add February 2026 Threads API updates

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -53,7 +53,7 @@ const (
 	UserProfileFields = "id,username,name,threads_profile_picture_url,threads_biography,is_verified"
 
 	// Reply fields (includes additional reply-specific fields)
-	ReplyFields = "id,media_product_type,media_type,media_url,permalink,username,text,timestamp,shortcode,thumbnail_url,children,is_quote_post,has_replies,root_post,replied_to,is_reply,is_reply_owned_by_me,reply_audience,quoted_post,reposted_post,gif_url,alt_text,hide_status,topic_tag,is_verified,profile_picture_url"
+	ReplyFields = "id,media_product_type,media_type,media_url,permalink,username,text,timestamp,shortcode,thumbnail_url,children,is_quote_post,has_replies,root_post,replied_to,is_reply,is_reply_owned_by_me,reply_audience,quoted_post,reposted_post,gif_url,alt_text,hide_status,topic_tag,is_verified,profile_picture_url,reply_approval_status"
 
 	// Container status fields
 	ContainerStatusFields = "id,status,error_message"

--- a/container_builder.go
+++ b/container_builder.go
@@ -211,6 +211,14 @@ func (b *ContainerBuilder) SetIsGhostPost(isGhostPost bool) *ContainerBuilder {
 	return b
 }
 
+// SetEnableReplyApprovals enables reply approvals on the post
+func (b *ContainerBuilder) SetEnableReplyApprovals(enable bool) *ContainerBuilder {
+	if enable {
+		b.params.Set("enable_reply_approvals", "true")
+	}
+	return b
+}
+
 // Build returns the built parameters
 func (b *ContainerBuilder) Build() url.Values {
 	return b.params

--- a/interfaces.go
+++ b/interfaces.go
@@ -167,6 +167,15 @@ type ReplyManager interface {
 
 	// GetUserReplies retrieves all replies by a user
 	GetUserReplies(ctx context.Context, userID UserID, opts *PostsOptions) (*RepliesResponse, error)
+
+	// GetPendingReplies retrieves pending replies for a post with reply approvals enabled
+	GetPendingReplies(ctx context.Context, postID PostID, opts *PendingRepliesOptions) (*RepliesResponse, error)
+
+	// ApprovePendingReply approves a pending reply, making it publicly visible
+	ApprovePendingReply(ctx context.Context, replyID PostID) error
+
+	// IgnorePendingReply ignores a pending reply (it can still be approved later)
+	IgnorePendingReply(ctx context.Context, replyID PostID) error
 }
 
 // InsightsProvider handles analytics and insights operations

--- a/posts_create.go
+++ b/posts_create.go
@@ -307,7 +307,8 @@ func (c *Client) createTextContainer(ctx context.Context, content *TextPostConte
 		SetTextEntities(content.TextEntities).
 		SetTextAttachment(content.TextAttachment).
 		SetGIFAttachment(content.GIFAttachment).
-		SetIsGhostPost(content.IsGhostPost)
+		SetIsGhostPost(content.IsGhostPost).
+		SetEnableReplyApprovals(content.EnableReplyApprovals)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -330,7 +331,8 @@ func (c *Client) createImageContainer(ctx context.Context, content *ImagePostCon
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
 		SetLocationID(content.LocationID).
 		SetTextEntities(content.TextEntities).
-		SetIsSpoilerMedia(content.IsSpoilerMedia)
+		SetIsSpoilerMedia(content.IsSpoilerMedia).
+		SetEnableReplyApprovals(content.EnableReplyApprovals)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -353,7 +355,8 @@ func (c *Client) createVideoContainer(ctx context.Context, content *VideoPostCon
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
 		SetLocationID(content.LocationID).
 		SetTextEntities(content.TextEntities).
-		SetIsSpoilerMedia(content.IsSpoilerMedia)
+		SetIsSpoilerMedia(content.IsSpoilerMedia).
+		SetEnableReplyApprovals(content.EnableReplyApprovals)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -380,7 +383,8 @@ func (c *Client) createCarouselContainer(ctx context.Context, content *CarouselP
 		SetAllowlistedCountryCodes(content.AllowlistedCountryCodes).
 		SetLocationID(content.LocationID).
 		SetTextEntities(content.TextEntities).
-		SetIsSpoilerMedia(content.IsSpoilerMedia)
+		SetIsSpoilerMedia(content.IsSpoilerMedia).
+		SetEnableReplyApprovals(content.EnableReplyApprovals)
 
 	// Add quoted post ID if this is a quote post
 	if content.QuotedPostID != "" {
@@ -406,7 +410,8 @@ func (c *Client) createAndPublishTextPostDirectly(ctx context.Context, content *
 		SetTextEntities(content.TextEntities).
 		SetTextAttachment(content.TextAttachment).
 		SetGIFAttachment(content.GIFAttachment).
-		SetIsGhostPost(content.IsGhostPost)
+		SetIsGhostPost(content.IsGhostPost).
+		SetEnableReplyApprovals(content.EnableReplyApprovals)
 
 	// Get user ID from token info
 	userID := c.getUserID()

--- a/posts_validation.go
+++ b/posts_validation.go
@@ -79,6 +79,12 @@ func (c *Client) ValidateTextPostContent(content *TextPostContent) error {
 				"Ghost posts cannot be replies",
 				"is_ghost_post")
 		}
+		if content.EnableReplyApprovals {
+			return NewValidationError(400,
+				"Invalid ghost post",
+				"Ghost posts cannot have reply approvals enabled",
+				"enable_reply_approvals")
+		}
 	}
 
 	return nil

--- a/replies.go
+++ b/replies.go
@@ -120,7 +120,7 @@ func (c *Client) GetPendingReplies(ctx context.Context, postID PostID, opts *Pen
 
 	// Build query parameters
 	params := url.Values{
-		"fields": {ReplyFields + ",reply_approval_status"},
+		"fields": {ReplyFields},
 	}
 
 	if opts != nil {

--- a/replies.go
+++ b/replies.go
@@ -107,6 +107,117 @@ func (c *Client) GetConversation(ctx context.Context, postID PostID, opts *Repli
 	return c.fetchRepliesData(path, params, postID, "conversation")
 }
 
+// GetPendingReplies retrieves pending replies for a post with reply approvals enabled
+func (c *Client) GetPendingReplies(ctx context.Context, postID PostID, opts *PendingRepliesOptions) (*RepliesResponse, error) {
+	if !postID.Valid() {
+		return nil, NewValidationError(400, ErrEmptyPostID, "Cannot retrieve pending replies without post ID", "post_id")
+	}
+
+	// Ensure we have a valid token
+	if err := c.EnsureValidToken(ctx); err != nil {
+		return nil, err
+	}
+
+	// Build query parameters
+	params := url.Values{
+		"fields": {ReplyFields + ",reply_approval_status"},
+	}
+
+	if opts != nil {
+		if opts.Limit > 0 {
+			if opts.Limit > 100 {
+				return nil, NewValidationError(400, "Limit too large", "Maximum limit is 100 pending replies per request", "limit")
+			}
+			params.Set("limit", fmt.Sprintf("%d", opts.Limit))
+		}
+		if opts.Before != "" {
+			params.Set("before", opts.Before)
+		}
+		if opts.After != "" {
+			params.Set("after", opts.After)
+		}
+		if opts.Reverse != nil {
+			params.Set("reverse", fmt.Sprintf("%t", *opts.Reverse))
+		}
+		if opts.ApprovalStatus != "" {
+			if opts.ApprovalStatus != ApprovalStatusPending && opts.ApprovalStatus != ApprovalStatusIgnored {
+				return nil, NewValidationError(400, "Invalid approval status", "Approval status must be 'pending' or 'ignored'", "approval_status")
+			}
+			params.Set("approval_status", string(opts.ApprovalStatus))
+		}
+	}
+
+	path := fmt.Sprintf("/%s/pending_replies", postID.String())
+	return c.fetchRepliesData(path, params, postID, "pending replies")
+}
+
+// ApprovePendingReply approves a pending reply, making it publicly visible
+func (c *Client) ApprovePendingReply(ctx context.Context, replyID PostID) error {
+	return c.managePendingReply(ctx, replyID, true)
+}
+
+// IgnorePendingReply ignores a pending reply (it can still be approved later)
+func (c *Client) IgnorePendingReply(ctx context.Context, replyID PostID) error {
+	return c.managePendingReply(ctx, replyID, false)
+}
+
+// managePendingReply handles approving or ignoring a pending reply
+func (c *Client) managePendingReply(ctx context.Context, replyID PostID, approve bool) error {
+	action := "approve"
+	if !approve {
+		action = "ignore"
+	}
+
+	if !replyID.Valid() {
+		return NewValidationError(400, "Reply ID is required", fmt.Sprintf("Cannot %s reply without ID", action), "reply_id")
+	}
+
+	// Ensure we have a valid token
+	if err := c.EnsureValidToken(ctx); err != nil {
+		return err
+	}
+
+	params := url.Values{
+		"approve": {fmt.Sprintf("%t", approve)},
+	}
+
+	path := fmt.Sprintf("/%s/manage_pending_reply", replyID.String())
+	resp, err := c.httpClient.POST(path, params, c.getAccessTokenSafe())
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == 404 {
+		return NewValidationError(404, "Reply not found", fmt.Sprintf("Reply with ID %s does not exist or is not a pending reply", replyID.String()), "reply_id")
+	}
+
+	if resp.StatusCode == 403 {
+		return NewAuthenticationError(403, "Access denied", fmt.Sprintf("Cannot %s reply %s - insufficient permissions or not the post owner", action, replyID.String()))
+	}
+
+	if resp.StatusCode != 200 {
+		return c.handleAPIError(resp)
+	}
+
+	var manageResp struct {
+		Success bool `json:"success"`
+	}
+
+	if len(resp.Body) > 0 {
+		if err := json.Unmarshal(resp.Body, &manageResp); err != nil {
+			if c.config.Logger != nil {
+				c.config.Logger.Warn(fmt.Sprintf("Could not parse %s reply response, but got 200 status", action), "reply_id", replyID.String())
+			}
+		}
+	}
+
+	if c.config.Logger != nil {
+		c.config.Logger.Info(fmt.Sprintf("Successfully %sd pending reply", action), "reply_id", replyID.String())
+	}
+
+	return nil
+}
+
 // manageReplyVisibility handles hiding and unhiding replies
 func (c *Client) manageReplyVisibility(ctx context.Context, replyID PostID, hide bool) error {
 	action := "hide"

--- a/types.go
+++ b/types.go
@@ -81,6 +81,8 @@ type Post struct {
 	// ProfilePictureURL is the URL of the post author's profile picture on Threads.
 	// Available for replies and mentions. For conversations, only available on direct replies.
 	ProfilePictureURL string `json:"profile_picture_url,omitempty"`
+	// ReplyApprovalStatus is the approval status of a pending reply ("pending" or "ignored")
+	ReplyApprovalStatus string `json:"reply_approval_status,omitempty"`
 }
 
 // User represents a Threads user profile with app-scoped data.
@@ -152,6 +154,8 @@ type TextPostContent struct {
 	GIFAttachment *GIFAttachment `json:"gif_attachment,omitempty"`
 	// IsGhostPost marks the post as a ghost post (text-only, expires in 24h, no replies allowed)
 	IsGhostPost bool `json:"is_ghost_post,omitempty"`
+	// EnableReplyApprovals enables reply approvals on the post; replies must be approved before publishing
+	EnableReplyApprovals bool `json:"enable_reply_approvals,omitempty"`
 }
 
 // ImagePostContent represents content for image posts.
@@ -173,6 +177,8 @@ type ImagePostContent struct {
 	TextEntities []TextEntity `json:"text_entities,omitempty"`
 	// IsSpoilerMedia marks the image as a spoiler
 	IsSpoilerMedia bool `json:"is_spoiler_media,omitempty"`
+	// EnableReplyApprovals enables reply approvals on the post; replies must be approved before publishing
+	EnableReplyApprovals bool `json:"enable_reply_approvals,omitempty"`
 }
 
 // VideoPostContent represents content for video posts.
@@ -194,6 +200,8 @@ type VideoPostContent struct {
 	TextEntities []TextEntity `json:"text_entities,omitempty"`
 	// IsSpoilerMedia marks the video as a spoiler
 	IsSpoilerMedia bool `json:"is_spoiler_media,omitempty"`
+	// EnableReplyApprovals enables reply approvals on the post; replies must be approved before publishing
+	EnableReplyApprovals bool `json:"enable_reply_approvals,omitempty"`
 }
 
 // CarouselPostContent represents content for carousel posts.
@@ -214,6 +222,8 @@ type CarouselPostContent struct {
 	TextEntities []TextEntity `json:"text_entities,omitempty"`
 	// IsSpoilerMedia marks ALL carousel media (images/videos) as spoilers
 	IsSpoilerMedia bool `json:"is_spoiler_media,omitempty"`
+	// EnableReplyApprovals enables reply approvals on the post; replies must be approved before publishing
+	EnableReplyApprovals bool `json:"enable_reply_approvals,omitempty"`
 }
 
 // ReplyControl defines who can reply to a post
@@ -320,6 +330,25 @@ type RepliesOptions struct {
 	Before  string `json:"before,omitempty"`
 	After   string `json:"after,omitempty"`
 	Reverse *bool  `json:"reverse,omitempty"` // true for reverse chronological, false for chronological (default: true)
+}
+
+// ApprovalStatus represents the approval status filter for pending replies
+type ApprovalStatus string
+
+const (
+	// ApprovalStatusPending filters to show only pending replies
+	ApprovalStatusPending ApprovalStatus = "pending"
+	// ApprovalStatusIgnored filters to show only ignored replies
+	ApprovalStatusIgnored ApprovalStatus = "ignored"
+)
+
+// PendingRepliesOptions represents options for retrieving pending replies
+type PendingRepliesOptions struct {
+	Limit          int            `json:"limit,omitempty"`
+	Before         string         `json:"before,omitempty"`
+	After          string         `json:"after,omitempty"`
+	Reverse        *bool          `json:"reverse,omitempty"`         // true for reverse chronological (default), false for chronological
+	ApprovalStatus ApprovalStatus `json:"approval_status,omitempty"` // Filter by approval status: "pending" or "ignored"
 }
 
 // SearchOptions represents options for keyword and topic tag search


### PR DESCRIPTION
## Summary

- Implement **Reply Approvals** feature from the February 13, 2026 Threads API changelog
- Add `EnableReplyApprovals` field to all post content types (text, image, video, carousel)
- Add `GetPendingReplies`, `ApprovePendingReply`, and `IgnorePendingReply` methods with full validation
- Add `ApprovalStatus` type (`pending`/`ignored`) for filtering pending replies
- Validate that ghost posts cannot have reply approvals enabled

## Test plan

- [x] Unit tests for reply approvals validation, container builder, and pending replies options
- [x] Integration tests for creating posts with reply approvals, querying pending replies, and validation errors
- [x] All existing tests pass (`go test ./... -short`)
- [x] `go build ./...` and `go vet ./...` clean