### PR TITLE
feat: Add March 2026 API updates and fix carousel ordering

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -338,6 +338,16 @@ func TestContainerBuilderSetChildren(t *testing.T) {
 		}
 	})
 
+	t.Run("SetChildren nil clears existing", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		builder.AddChild("id1").AddChild("id2")
+		params := builder.SetChildren(nil).Build()
+
+		if params.Get("children") != "" {
+			t.Error("Expected SetChildren(nil) to clear existing children")
+		}
+	})
+
 	t.Run("no indexed params", func(t *testing.T) {
 		builder := NewContainerBuilder()
 		childIDs := []string{"id1", "id2", "id3"}

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,8 @@
 package threads
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -296,6 +298,70 @@ func TestContainerBuilder(t *testing.T) {
 
 	if params.Get("reply_control") != string(ReplyControlEveryone) {
 		t.Errorf("Expected reply_control to be %s, got %s", string(ReplyControlEveryone), params.Get("reply_control"))
+	}
+}
+
+func TestContainerBuilderSetChildren(t *testing.T) {
+	t.Run("comma separated format", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		childIDs := []string{"id1", "id2", "id3", "id4", "id5"}
+		params := builder.SetChildren(childIDs).Build()
+
+		got := params.Get("children")
+		expected := "id1,id2,id3,id4,id5"
+		if got != expected {
+			t.Errorf("Expected children=%q, got %q", expected, got)
+		}
+	})
+
+	t.Run("preserves order with 10+ children", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		childIDs := make([]string, 20)
+		for i := range childIDs {
+			childIDs[i] = fmt.Sprintf("id_%d", i+1)
+		}
+		params := builder.SetChildren(childIDs).Build()
+
+		got := params.Get("children")
+		expected := strings.Join(childIDs, ",")
+		if got != expected {
+			t.Errorf("Children order not preserved.\nExpected: %s\nGot:      %s", expected, got)
+		}
+	})
+
+	t.Run("empty children", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetChildren(nil).Build()
+
+		if params.Get("children") != "" {
+			t.Error("Expected no children param for nil input")
+		}
+	})
+
+	t.Run("no indexed params", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		childIDs := []string{"id1", "id2", "id3"}
+		params := builder.SetChildren(childIDs).Build()
+
+		encoded := params.Encode()
+		if strings.Contains(encoded, "children%5B") || strings.Contains(encoded, "children[") {
+			t.Errorf("Should not contain indexed children params, got: %s", encoded)
+		}
+	})
+}
+
+func TestContainerBuilderAddChild(t *testing.T) {
+	builder := NewContainerBuilder()
+	params := builder.
+		AddChild("id1").
+		AddChild("id2").
+		AddChild("id3").
+		Build()
+
+	got := params.Get("children")
+	expected := "id1,id2,id3"
+	if got != expected {
+		t.Errorf("Expected children=%q, got %q", expected, got)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -392,10 +392,18 @@ func TestValidateGIFAttachment(t *testing.T) {
 			errField:  "gif_attachment.provider",
 		},
 		{
+			name: "valid giphy provider",
+			gif: &GIFAttachment{
+				GIFID:    "test-gif-id",
+				Provider: GIFProviderGiphy,
+			},
+			shouldErr: false,
+		},
+		{
 			name: "invalid provider",
 			gif: &GIFAttachment{
 				GIFID:    "test-gif-id",
-				Provider: GIFProvider("GIPHY"),
+				Provider: GIFProvider("INVALID"),
 			},
 			shouldErr: true,
 			errField:  "gif_attachment.provider",
@@ -423,9 +431,11 @@ func TestValidateGIFAttachment(t *testing.T) {
 }
 
 func TestGIFProviderConstants(t *testing.T) {
-	// Verify the TENOR constant is correctly defined
 	if GIFProviderTenor != "TENOR" {
 		t.Errorf("Expected GIFProviderTenor to be 'TENOR', got '%s'", GIFProviderTenor)
+	}
+	if GIFProviderGiphy != "GIPHY" {
+		t.Errorf("Expected GIFProviderGiphy to be 'GIPHY', got '%s'", GIFProviderGiphy)
 	}
 }
 

--- a/container_builder.go
+++ b/container_builder.go
@@ -125,6 +125,9 @@ func (b *ContainerBuilder) SetAllowlistedCountryCodes(codes []string) *Container
 
 // AddChild adds a child container ID (for carousel posts)
 func (b *ContainerBuilder) AddChild(childID string) *ContainerBuilder {
+	if childID == "" {
+		return b
+	}
 	existing := b.params.Get("children")
 	if existing != "" {
 		b.params.Set("children", existing+","+childID)

--- a/container_builder.go
+++ b/container_builder.go
@@ -136,9 +136,11 @@ func (b *ContainerBuilder) AddChild(childID string) *ContainerBuilder {
 
 // SetChildren sets all children container IDs at once (for carousel posts)
 func (b *ContainerBuilder) SetChildren(childIDs []string) *ContainerBuilder {
-	if len(childIDs) > 0 {
-		b.params.Set("children", strings.Join(childIDs, ","))
+	if len(childIDs) == 0 {
+		b.params.Del("children")
+		return b
 	}
+	b.params.Set("children", strings.Join(childIDs, ","))
 	return b
 }
 

--- a/container_builder.go
+++ b/container_builder.go
@@ -125,16 +125,19 @@ func (b *ContainerBuilder) SetAllowlistedCountryCodes(codes []string) *Container
 
 // AddChild adds a child container ID (for carousel posts)
 func (b *ContainerBuilder) AddChild(childID string) *ContainerBuilder {
-	b.params.Add("children", childID)
+	existing := b.params.Get("children")
+	if existing != "" {
+		b.params.Set("children", existing+","+childID)
+	} else {
+		b.params.Set("children", childID)
+	}
 	return b
 }
 
 // SetChildren sets all children container IDs at once (for carousel posts)
 func (b *ContainerBuilder) SetChildren(childIDs []string) *ContainerBuilder {
-	for i, childID := range childIDs {
-		b.params.Add("children", childID)
-		// Also add as indexed parameter for API compatibility
-		b.params.Set(b.childIndexKey(i), childID)
+	if len(childIDs) > 0 {
+		b.params.Set("children", strings.Join(childIDs, ","))
 	}
 	return b
 }
@@ -222,35 +225,4 @@ func (b *ContainerBuilder) SetEnableReplyApprovals(enable bool) *ContainerBuilde
 // Build returns the built parameters
 func (b *ContainerBuilder) Build() url.Values {
 	return b.params
-}
-
-// childIndexKey generates the indexed child parameter key
-func (b *ContainerBuilder) childIndexKey(index int) string {
-	return "children[" + b.toString(index) + "]"
-}
-
-// toString converts an interface to string
-func (b *ContainerBuilder) toString(v interface{}) string {
-	switch val := v.(type) {
-	case string:
-		return val
-	case int:
-		// Convert int to string manually
-		if val == 0 {
-			return "0"
-		}
-		sign := ""
-		if val < 0 {
-			sign = "-"
-			val = -val
-		}
-		result := ""
-		for val > 0 {
-			result = string(rune('0'+val%10)) + result
-			val /= 10
-		}
-		return sign + result
-	default:
-		return ""
-	}
 }

--- a/container_builder.go
+++ b/container_builder.go
@@ -192,7 +192,7 @@ func (b *ContainerBuilder) SetTextAttachment(textAttachment *TextAttachment) *Co
 
 // SetGIFAttachment adds a GIF attachment to the post
 // Can only be used with TEXT-only posts (not with image, video, or carousel posts)
-// Tenor is currently the only available GIF provider
+// Supported providers: TENOR (deprecated, sunset March 31, 2026) and GIPHY
 func (b *ContainerBuilder) SetGIFAttachment(gifAttachment *GIFAttachment) *ContainerBuilder {
 	if gifAttachment != nil {
 		attachmentJSON, err := json.Marshal(gifAttachment)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1057,7 +1057,7 @@ func TestIntegration_GIFValidationErrors(t *testing.T) {
 			Text: "This should fail validation - invalid provider",
 			GIFAttachment: &threads.GIFAttachment{
 				GIFID:    "11366929630539488910",
-				Provider: threads.GIFProvider("GIPHY"), // Invalid provider
+				Provider: threads.GIFProvider("INVALID"),
 			},
 		}
 

--- a/types.go
+++ b/types.go
@@ -150,7 +150,7 @@ type TextPostContent struct {
 	TextAttachment *TextAttachment `json:"text_attachment,omitempty"`
 	// GIFAttachment allows attaching a GIF to the text post
 	// Can only be used with TEXT-only posts (not with image, video, or carousel posts)
-	// Tenor is currently the only available GIF provider
+	// Supported providers: TENOR (deprecated) and GIPHY
 	GIFAttachment *GIFAttachment `json:"gif_attachment,omitempty"`
 	// IsGhostPost marks the post as a ghost post (text-only, expires in 24h, no replies allowed)
 	IsGhostPost bool `json:"is_ghost_post,omitempty"`
@@ -512,16 +512,19 @@ type TextStylingInfo struct {
 type GIFProvider string
 
 const (
-	// GIFProviderTenor is the Tenor GIF provider (currently the only supported provider)
+	// GIFProviderTenor is the Tenor GIF provider.
+	// Deprecated: Tenor API will be sunsetted by March 31, 2026. Use GIFProviderGiphy instead.
 	GIFProviderTenor GIFProvider = "TENOR"
+	// GIFProviderGiphy is the GIPHY GIF provider
+	GIFProviderGiphy GIFProvider = "GIPHY"
 )
 
 // GIFAttachment represents a GIF attachment for text posts
 // GIFs can only be attached to text-only posts (not image, video, or carousel posts)
-// Tenor is currently the only available GIF provider
+// Supported providers: TENOR (deprecated, sunset March 31, 2026) and GIPHY
 type GIFAttachment struct {
-	// GIFID is the ID of the GIF from the provider (e.g., Tenor API response id field)
+	// GIFID is the ID of the GIF from the provider's API response
 	GIFID string `json:"gif_id"`
-	// Provider is the GIF provider (currently only "TENOR" is supported)
+	// Provider is the GIF provider ("TENOR" or "GIPHY")
 	Provider GIFProvider `json:"provider"`
 }

--- a/validation.go
+++ b/validation.go
@@ -325,11 +325,11 @@ func (v *Validator) ValidateGIFAttachment(gifAttachment *GIFAttachment) error {
 			"gif_attachment.provider")
 	}
 
-	// Currently only TENOR is supported
-	if gifAttachment.Provider != GIFProviderTenor {
+	// Validate provider is a supported value
+	if gifAttachment.Provider != GIFProviderTenor && gifAttachment.Provider != GIFProviderGiphy {
 		return NewValidationError(400,
 			"Invalid GIF provider",
-			fmt.Sprintf("GIF provider '%s' is not supported. Currently only 'TENOR' is supported", gifAttachment.Provider),
+			fmt.Sprintf("GIF provider '%s' is not supported. Supported providers: 'TENOR', 'GIPHY'", gifAttachment.Provider),
 			"gif_attachment.provider")
 	}
 


### PR DESCRIPTION
## Summary

- Add `GIFProviderGiphy` constant per February 27, 2026 changelog (GIPHY now supported)
- Mark `GIFProviderTenor` as deprecated (Tenor API sunset March 31, 2026)
- Update validation to accept both TENOR and GIPHY providers
- Fix carousel children ordering bug: `SetChildren` was using indexed params (`children[0]`, `children[1]`, etc.) which sort lexicographically, causing items 10+ to appear out of order. Now uses comma-separated format as expected by the Graph API.

## Test plan

- [x] Unit tests for GIPHY provider constant and validation
- [x] Unit tests for `SetChildren` with 20+ items verifying order preservation
- [x] Unit test verifying no indexed params (`children[N]`) are produced
- [x] Unit test for `AddChild` accumulation
- [x] All existing tests pass (`go test ./... -short`)
- [x] `go build ./...` and `go vet ./...` clean