### PR TITLE
fix: improve retry logic, error metadata, and container lifecycle

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -668,6 +668,43 @@ func (n *noopLogger) Info(msg string, fields ...any)  {}
 func (n *noopLogger) Warn(msg string, fields ...any)  {}
 func (n *noopLogger) Error(msg string, fields ...any) {}
 
+func TestIsRetryableErrorWithTransientAPIError(t *testing.T) {
+	h := &HTTPClient{
+		logger:      &noopLogger{},
+		retryConfig: &RetryConfig{MaxRetries: 3, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 2},
+	}
+
+	// API error with code 2 but HTTP status 500 — should be retryable
+	apiErr := NewAPIError(2, "An unexpected error", "details", "trace")
+	apiErr.HTTPStatusCode = 500
+	apiErr.IsTransient = true
+	if !h.isRetryableError(apiErr) {
+		t.Error("Expected transient API error with HTTP 500 to be retryable")
+	}
+
+	// API error with code 2, HTTP status 500, is_transient false — still retryable (5xx)
+	apiErr2 := NewAPIError(2, "An unexpected error", "details", "trace")
+	apiErr2.HTTPStatusCode = 500
+	if !h.isRetryableError(apiErr2) {
+		t.Error("Expected API error with HTTP 500 to be retryable regardless of is_transient")
+	}
+
+	// API error with code 24, HTTP status 400, not transient — NOT retryable
+	valErr := NewValidationError(24, "Resource not found", "details", "")
+	valErr.HTTPStatusCode = 400
+	if h.isRetryableError(valErr) {
+		t.Error("Expected non-transient 400 error to NOT be retryable")
+	}
+
+	// Transient error with non-5xx status — retryable because is_transient=true
+	transientErr := NewValidationError(2, "Unexpected error", "details", "")
+	transientErr.HTTPStatusCode = 400
+	transientErr.IsTransient = true
+	if !h.isRetryableError(transientErr) {
+		t.Error("Expected transient error to be retryable even with non-5xx HTTP status")
+	}
+}
+
 func TestSearchOptionsAuthorUsername(t *testing.T) {
 	opts := &SearchOptions{
 		AuthorUsername: "testuser",

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package threads
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -608,6 +609,64 @@ func TestPendingRepliesOptionsApprovalStatus(t *testing.T) {
 		t.Errorf("Expected ApprovalStatus to be 'pending', got '%s'", opts.ApprovalStatus)
 	}
 }
+
+func TestErrorIsTransient(t *testing.T) {
+	apiErr := NewAPIError(2, "An unexpected error", "details", "trace-123")
+	apiErr.IsTransient = true
+	if !apiErr.IsTransient {
+		t.Error("Expected IsTransient to be true")
+	}
+	validErr := NewValidationError(400, "Bad request", "details", "field")
+	if validErr.IsTransient {
+		t.Error("Expected IsTransient to default to false")
+	}
+}
+
+func TestCreateErrorFromResponseParsesIsTransient(t *testing.T) {
+	h := &HTTPClient{
+		logger:      &noopLogger{},
+		retryConfig: &RetryConfig{MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 2},
+	}
+
+	body := []byte(`{"error":{"message":"An unexpected error","type":"OAuthException","code":2,"is_transient":true}}`)
+	resp := &Response{
+		Body:       body,
+		StatusCode: 500,
+		RequestID:  "test-trace",
+	}
+
+	err := h.createErrorFromResponse(resp)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Expected APIError, got %T: %v", err, err)
+	}
+	if !apiErr.IsTransient {
+		t.Error("Expected IsTransient to be true for transient API error")
+	}
+
+	body2 := []byte(`{"error":{"message":"Resource not found","type":"OAuthException","code":24,"is_transient":false}}`)
+	resp2 := &Response{
+		Body:       body2,
+		StatusCode: 400,
+		RequestID:  "test-trace-2",
+	}
+
+	err2 := h.createErrorFromResponse(resp2)
+	var valErr *ValidationError
+	if !errors.As(err2, &valErr) {
+		t.Fatalf("Expected ValidationError, got %T: %v", err2, err2)
+	}
+	if valErr.IsTransient {
+		t.Error("Expected IsTransient to be false for non-transient error")
+	}
+}
+
+type noopLogger struct{}
+
+func (n *noopLogger) Debug(msg string, fields ...any) {}
+func (n *noopLogger) Info(msg string, fields ...any)  {}
+func (n *noopLogger) Warn(msg string, fields ...any)  {}
+func (n *noopLogger) Error(msg string, fields ...any) {}
 
 func TestSearchOptionsAuthorUsername(t *testing.T) {
 	opts := &SearchOptions{

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -722,6 +724,12 @@ func TestIsTransientErrorHelper(t *testing.T) {
 	if IsTransientError(fmt.Errorf("random error")) {
 		t.Error("Expected IsTransientError to return false for non-threads error")
 	}
+
+	// Wrapped transient error should still be detected
+	wrappedErr := fmt.Errorf("operation failed: %w", transientErr)
+	if !IsTransientError(wrappedErr) {
+		t.Error("Expected IsTransientError to return true for wrapped transient error")
+	}
 }
 
 func TestErrorSubcode(t *testing.T) {
@@ -774,12 +782,40 @@ func TestSearchOptionsAuthorUsername(t *testing.T) {
 }
 
 func TestWaitForContainerReadyRespectsContext(t *testing.T) {
-	client := &Client{}
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	// Serve IN_PROGRESS status so the poll loop blocks on the select
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":"fake-id","status":"IN_PROGRESS"}`))
+	}))
+	defer ts.Close()
+
+	config := NewConfig()
+	config.ClientID = "test"
+	config.ClientSecret = "test"
+	config.RedirectURI = "http://localhost"
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	// Point HTTP client at test server and set a valid token
+	client.httpClient.baseURL = ts.URL
+	client.tokenInfo = &TokenInfo{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+		CreatedAt:   time.Now(),
+	}
+	client.accessToken = "test-token"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 
-	err := client.waitForContainerReady(ctx, ContainerID("fake-id"), 100, 1*time.Second)
+	err = client.waitForContainerReady(ctx, ContainerID("fake-id"), 100, 1*time.Second)
 	if err == nil {
-		t.Error("Expected error when context is cancelled")
+		t.Fatal("Expected error when context times out")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Expected context.DeadlineExceeded, got: %v", err)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package threads
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -705,6 +706,56 @@ func TestIsRetryableErrorWithTransientAPIError(t *testing.T) {
 	}
 }
 
+func TestIsTransientErrorHelper(t *testing.T) {
+	transientErr := NewAPIError(2, "Unexpected error", "details", "trace")
+	transientErr.IsTransient = true
+
+	if !IsTransientError(transientErr) {
+		t.Error("Expected IsTransientError to return true")
+	}
+
+	nonTransientErr := NewValidationError(24, "Not found", "details", "")
+	if IsTransientError(nonTransientErr) {
+		t.Error("Expected IsTransientError to return false")
+	}
+
+	if IsTransientError(fmt.Errorf("random error")) {
+		t.Error("Expected IsTransientError to return false for non-threads error")
+	}
+}
+
+func TestErrorSubcode(t *testing.T) {
+	apiErr := NewAPIError(24, "Resource not found", "details", "trace")
+	apiErr.ErrorSubcode = 4279009
+
+	if apiErr.ErrorSubcode != 4279009 {
+		t.Errorf("Expected ErrorSubcode 4279009, got %d", apiErr.ErrorSubcode)
+	}
+}
+
+func TestCreateErrorFromResponseParsesErrorSubcode(t *testing.T) {
+	h := &HTTPClient{
+		logger:      &noopLogger{},
+		retryConfig: &RetryConfig{MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 2},
+	}
+
+	body := []byte(`{"error":{"message":"Media not found","type":"OAuthException","code":24,"is_transient":false,"error_subcode":4279009}}`)
+	resp := &Response{
+		Body:       body,
+		StatusCode: 400,
+		RequestID:  "test-trace",
+	}
+
+	err := h.createErrorFromResponse(resp)
+	var valErr *ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("Expected ValidationError, got %T: %v", err, err)
+	}
+	if valErr.ErrorSubcode != 4279009 {
+		t.Errorf("Expected ErrorSubcode 4279009, got %d", valErr.ErrorSubcode)
+	}
+}
+
 func TestSearchOptionsAuthorUsername(t *testing.T) {
 	opts := &SearchOptions{
 		AuthorUsername: "testuser",
@@ -719,5 +770,16 @@ func TestSearchOptionsAuthorUsername(t *testing.T) {
 	opts.AuthorUsername = "@testuser"
 	if opts.AuthorUsername != "@testuser" {
 		t.Errorf("Expected AuthorUsername to be '@testuser', got '%s'", opts.AuthorUsername)
+	}
+}
+
+func TestWaitForContainerReadyRespectsContext(t *testing.T) {
+	client := &Client{}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := client.waitForContainerReady(ctx, ContainerID("fake-id"), 100, 1*time.Second)
+	if err == nil {
+		t.Error("Expected error when context is cancelled")
 	}
 }

--- a/client_utils.go
+++ b/client_utils.go
@@ -3,6 +3,7 @@ package threads
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // getUserID extracts user ID from token info
@@ -48,7 +49,10 @@ func (c *Client) handleAPIError(resp *Response) error {
 			case 401, 403:
 				resultErr = NewAuthenticationError(errorCode, message, details)
 			case 429:
-				retryAfter := resp.RateLimit.RetryAfter
+				var retryAfter time.Duration
+				if resp.RateLimit != nil {
+					retryAfter = resp.RateLimit.RetryAfter
+				}
 				resultErr = NewRateLimitError(errorCode, message, details, retryAfter)
 			case 400, 422:
 				resultErr = NewValidationError(errorCode, message, details, "")

--- a/client_utils.go
+++ b/client_utils.go
@@ -55,9 +55,10 @@ func (c *Client) handleAPIError(resp *Response) error {
 				resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 			}
 
-			// Set IsTransient on the base error
+			// Set IsTransient and HTTPStatusCode on the base error
 			if base := extractBaseError(resultErr); base != nil {
 				base.IsTransient = isTransient
+				base.HTTPStatusCode = resp.StatusCode
 			}
 
 			return resultErr
@@ -71,5 +72,7 @@ func (c *Client) handleAPIError(resp *Response) error {
 		details = details[:500] + "..."
 	}
 
-	return NewAPIError(resp.StatusCode, message, details, resp.RequestID)
+	fallbackErr := NewAPIError(resp.StatusCode, message, details, resp.RequestID)
+	fallbackErr.HTTPStatusCode = resp.StatusCode
+	return fallbackErr
 }

--- a/client_utils.go
+++ b/client_utils.go
@@ -56,13 +56,7 @@ func (c *Client) handleAPIError(resp *Response) error {
 				resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 			}
 
-			// Set IsTransient, HTTPStatusCode, and ErrorSubcode on the base error
-			if base := extractBaseError(resultErr); base != nil {
-				base.IsTransient = isTransient
-				base.HTTPStatusCode = resp.StatusCode
-				base.ErrorSubcode = apiErr.Error.ErrorSubcode
-			}
-
+			setErrorMetadata(resultErr, isTransient, resp.StatusCode, apiErr.Error.ErrorSubcode)
 			return resultErr
 		}
 	}
@@ -75,6 +69,6 @@ func (c *Client) handleAPIError(resp *Response) error {
 	}
 
 	fallbackErr := NewAPIError(resp.StatusCode, message, details, resp.RequestID)
-	fallbackErr.HTTPStatusCode = resp.StatusCode
+	setErrorMetadata(fallbackErr, false, resp.StatusCode, 0)
 	return fallbackErr
 }

--- a/client_utils.go
+++ b/client_utils.go
@@ -20,10 +20,11 @@ func (c *Client) getUserID() string {
 func (c *Client) handleAPIError(resp *Response) error {
 	var apiErr struct {
 		Error struct {
-			Message   string `json:"message"`
-			Type      string `json:"type"`
-			Code      int    `json:"code"`
-			ErrorData struct {
+			Message     string `json:"message"`
+			Type        string `json:"type"`
+			Code        int    `json:"code"`
+			IsTransient bool   `json:"is_transient"`
+			ErrorData   struct {
 				Details string `json:"details"`
 			} `json:"error_data"`
 		} `json:"error"`
@@ -35,22 +36,31 @@ func (c *Client) handleAPIError(resp *Response) error {
 			message := apiErr.Error.Message
 			details := apiErr.Error.ErrorData.Details
 			errorCode := apiErr.Error.Code
+			isTransient := apiErr.Error.IsTransient
 			if errorCode == 0 {
 				errorCode = resp.StatusCode
 			}
 
 			// Return appropriate error type based on status code
+			var resultErr error
 			switch resp.StatusCode {
 			case 401, 403:
-				return NewAuthenticationError(errorCode, message, details)
+				resultErr = NewAuthenticationError(errorCode, message, details)
 			case 429:
 				retryAfter := resp.RateLimit.RetryAfter
-				return NewRateLimitError(errorCode, message, details, retryAfter)
+				resultErr = NewRateLimitError(errorCode, message, details, retryAfter)
 			case 400, 422:
-				return NewValidationError(errorCode, message, details, "")
+				resultErr = NewValidationError(errorCode, message, details, "")
 			default:
-				return NewAPIError(errorCode, message, details, resp.RequestID)
+				resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 			}
+
+			// Set IsTransient on the base error
+			if base := extractBaseError(resultErr); base != nil {
+				base.IsTransient = isTransient
+			}
+
+			return resultErr
 		}
 	}
 

--- a/client_utils.go
+++ b/client_utils.go
@@ -20,11 +20,12 @@ func (c *Client) getUserID() string {
 func (c *Client) handleAPIError(resp *Response) error {
 	var apiErr struct {
 		Error struct {
-			Message     string `json:"message"`
-			Type        string `json:"type"`
-			Code        int    `json:"code"`
-			IsTransient bool   `json:"is_transient"`
-			ErrorData   struct {
+			Message      string `json:"message"`
+			Type         string `json:"type"`
+			Code         int    `json:"code"`
+			IsTransient  bool   `json:"is_transient"`
+			ErrorSubcode int    `json:"error_subcode"`
+			ErrorData    struct {
 				Details string `json:"details"`
 			} `json:"error_data"`
 		} `json:"error"`
@@ -55,10 +56,11 @@ func (c *Client) handleAPIError(resp *Response) error {
 				resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 			}
 
-			// Set IsTransient and HTTPStatusCode on the base error
+			// Set IsTransient, HTTPStatusCode, and ErrorSubcode on the base error
 			if base := extractBaseError(resultErr); base != nil {
 				base.IsTransient = isTransient
 				base.HTTPStatusCode = resp.StatusCode
+				base.ErrorSubcode = apiErr.Error.ErrorSubcode
 			}
 
 			return resultErr

--- a/errors.go
+++ b/errors.go
@@ -99,13 +99,26 @@ func NewValidationError(code int, message, details, field string) *ValidationErr
 // error is likely transient and the request can be retried.
 type NetworkError struct {
 	*BaseError
-	Temporary bool `json:"temporary"`
+	Temporary bool  `json:"temporary"`
+	Cause     error `json:"-"`
+}
+
+// Unwrap returns the underlying error, enabling errors.Is/errors.As
+// to inspect the original cause (e.g., context.Canceled).
+func (e *NetworkError) Unwrap() error {
+	return e.Cause
 }
 
 // NewNetworkError creates a new network error with temporary status.
 // Set temporary to true for transient errors that may succeed on retry.
 // The code may be 0 for client-side network failures.
 func NewNetworkError(code int, message, details string, temporary bool) *NetworkError {
+	return NewNetworkErrorWithCause(code, message, details, temporary, nil)
+}
+
+// NewNetworkErrorWithCause creates a new network error that wraps an underlying cause.
+// The cause is accessible via Unwrap(), enabling errors.Is/errors.As on the original error.
+func NewNetworkErrorWithCause(code int, message, details string, temporary bool, cause error) *NetworkError {
 	return &NetworkError{
 		BaseError: &BaseError{
 			Code:    code,
@@ -114,6 +127,7 @@ func NewNetworkError(code int, message, details string, temporary bool) *Network
 			Details: details,
 		},
 		Temporary: temporary,
+		Cause:     cause,
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -159,6 +159,15 @@ func extractBaseError(err error) *BaseError {
 	}
 }
 
+// setErrorMetadata sets transient flag, HTTP status code, and error subcode on any typed error.
+func setErrorMetadata(err error, isTransient bool, httpStatusCode, errorSubcode int) {
+	if base := extractBaseError(err); base != nil {
+		base.IsTransient = isTransient
+		base.HTTPStatusCode = httpStatusCode
+		base.ErrorSubcode = errorSubcode
+	}
+}
+
 // IsAuthenticationError checks if an error is an authentication error.
 // This is useful for implementing retry logic or handling authentication failures.
 // Returns true if the error is of type *AuthenticationError.

--- a/errors.go
+++ b/errors.go
@@ -15,6 +15,7 @@ type BaseError struct {
 	Details        string `json:"details,omitempty"`
 	IsTransient    bool   `json:"is_transient,omitempty"`
 	HTTPStatusCode int    `json:"http_status_code,omitempty"`
+	ErrorSubcode   int    `json:"error_subcode,omitempty"`
 }
 
 // Error implements the error interface
@@ -201,4 +202,13 @@ func IsAPIError(err error) bool {
 	var APIError *APIError
 	ok := errors.As(err, &APIError)
 	return ok
+}
+
+// IsTransientError checks if an error is marked as transient by the API.
+// Transient errors are temporary and the request can be retried.
+func IsTransientError(err error) bool {
+	if baseErr := extractBaseError(err); baseErr != nil {
+		return baseErr.IsTransient
+	}
+	return false
 }

--- a/errors.go
+++ b/errors.go
@@ -9,11 +9,12 @@ import (
 // BaseError represents a base error type for all Threads API errors.
 // For error handling patterns, see: https://developers.facebook.com/docs/threads/troubleshooting
 type BaseError struct {
-	Code        int    `json:"code"`
-	Message     string `json:"message"`
-	Type        string `json:"type"`
-	Details     string `json:"details,omitempty"`
-	IsTransient bool   `json:"is_transient,omitempty"`
+	Code           int    `json:"code"`
+	Message        string `json:"message"`
+	Type           string `json:"type"`
+	Details        string `json:"details,omitempty"`
+	IsTransient    bool   `json:"is_transient,omitempty"`
+	HTTPStatusCode int    `json:"http_status_code,omitempty"`
 }
 
 // Error implements the error interface

--- a/errors.go
+++ b/errors.go
@@ -215,9 +215,27 @@ func IsAPIError(err error) bool {
 
 // IsTransientError checks if an error is marked as transient by the API.
 // Transient errors are temporary and the request can be retried.
+// Uses errors.As to support wrapped errors, consistent with other IsXxx helpers.
 func IsTransientError(err error) bool {
-	if baseErr := extractBaseError(err); baseErr != nil {
-		return baseErr.IsTransient
+	var authErr *AuthenticationError
+	if errors.As(err, &authErr) {
+		return authErr.IsTransient
+	}
+	var rateLimitErr *RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return rateLimitErr.IsTransient
+	}
+	var validationErr *ValidationError
+	if errors.As(err, &validationErr) {
+		return validationErr.IsTransient
+	}
+	var networkErr *NetworkError
+	if errors.As(err, &networkErr) {
+		return networkErr.IsTransient
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.IsTransient
 	}
 	return false
 }

--- a/errors.go
+++ b/errors.go
@@ -9,10 +9,11 @@ import (
 // BaseError represents a base error type for all Threads API errors.
 // For error handling patterns, see: https://developers.facebook.com/docs/threads/troubleshooting
 type BaseError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-	Type    string `json:"type"`
-	Details string `json:"details,omitempty"`
+	Code        int    `json:"code"`
+	Message     string `json:"message"`
+	Type        string `json:"type"`
+	Details     string `json:"details,omitempty"`
+	IsTransient bool   `json:"is_transient,omitempty"`
 }
 
 // Error implements the error interface
@@ -134,6 +135,25 @@ func NewAPIError(code int, message, details, requestID string) *APIError {
 			Details: details,
 		},
 		RequestID: requestID,
+	}
+}
+
+// extractBaseError returns the embedded BaseError from any of the typed error types.
+// Returns nil if the error is not one of the known types.
+func extractBaseError(err error) *BaseError {
+	switch e := err.(type) {
+	case *AuthenticationError:
+		return e.BaseError
+	case *RateLimitError:
+		return e.BaseError
+	case *ValidationError:
+		return e.BaseError
+	case *NetworkError:
+		return e.BaseError
+	case *APIError:
+		return e.BaseError
+	default:
+		return nil
 	}
 }
 

--- a/http_client.go
+++ b/http_client.go
@@ -329,20 +329,22 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 	return resultErr
 }
 
-// wrapNetworkError wraps network errors with appropriate error types
+// wrapNetworkError wraps network errors with appropriate error types.
+// The original error is preserved as the Cause, so errors.Is/errors.As
+// can inspect it (e.g., to detect context.Canceled).
 func (h *HTTPClient) wrapNetworkError(err error) error {
 	// Check for timeout errors
 	if timeoutErr, ok := err.(interface{ Timeout() bool }); ok && timeoutErr.Timeout() {
-		return NewNetworkError(0, "Request timeout", err.Error(), true)
+		return NewNetworkErrorWithCause(0, "Request timeout", err.Error(), true, err)
 	}
 
 	// Check for temporary errors
 	if tempErr, ok := err.(interface{ Temporary() bool }); ok && tempErr.Temporary() {
-		return NewNetworkError(0, "Temporary network error", err.Error(), true)
+		return NewNetworkErrorWithCause(0, "Temporary network error", err.Error(), true, err)
 	}
 
 	// Default to permanent network error
-	return NewNetworkError(0, "Network error", err.Error(), false)
+	return NewNetworkErrorWithCause(0, "Network error", err.Error(), false, err)
 }
 
 // isRetryableError determines if an error should trigger a retry

--- a/http_client.go
+++ b/http_client.go
@@ -270,10 +270,11 @@ func (h *HTTPClient) parseRateLimitHeaders(headers http.Header) *RateLimitInfo {
 func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 	var apiErr struct {
 		Error struct {
-			Message     string `json:"message"`
-			Type        string `json:"type"`
-			Code        int    `json:"code"`
-			IsTransient bool   `json:"is_transient"`
+			Message      string `json:"message"`
+			Type         string `json:"type"`
+			Code         int    `json:"code"`
+			IsTransient  bool   `json:"is_transient"`
+			ErrorSubcode int    `json:"error_subcode"`
 		} `json:"error"`
 	}
 
@@ -334,10 +335,11 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 		resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 	}
 
-	// Set IsTransient and HTTPStatusCode on the base error
+	// Set IsTransient, HTTPStatusCode, and ErrorSubcode on the base error
 	if base := extractBaseError(resultErr); base != nil {
 		base.IsTransient = isTransient
 		base.HTTPStatusCode = resp.StatusCode
+		base.ErrorSubcode = apiErr.Error.ErrorSubcode
 	}
 
 	return resultErr

--- a/http_client.go
+++ b/http_client.go
@@ -294,9 +294,7 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 	// Create specific error types based on status code
 	var resultErr error
 	switch resp.StatusCode {
-	case 401:
-		resultErr = NewAuthenticationError(errorCode, message, details)
-	case 403:
+	case 401, 403:
 		resultErr = NewAuthenticationError(errorCode, message, details)
 	case 429:
 		retryAfter := time.Duration(0)
@@ -322,18 +320,11 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 		resultErr = NewRateLimitError(errorCode, message, details, retryAfter)
 	case 400, 422:
 		resultErr = NewValidationError(errorCode, message, details, "")
-	case 500, 502, 503, 504:
-		resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 	default:
 		resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 	}
 
-	// Set IsTransient, HTTPStatusCode, and ErrorSubcode on the base error
-	if base := extractBaseError(resultErr); base != nil {
-		base.IsTransient = isTransient
-		base.HTTPStatusCode = resp.StatusCode
-		base.ErrorSubcode = apiErr.Error.ErrorSubcode
-	}
+	setErrorMetadata(resultErr, isTransient, resp.StatusCode, apiErr.Error.ErrorSubcode)
 
 	return resultErr
 }

--- a/http_client.go
+++ b/http_client.go
@@ -119,13 +119,6 @@ func (h *HTTPClient) Do(opts *RequestOptions, accessToken string) (*Response, er
 			h.rateLimiter.UpdateFromHeaders(resp.RateLimit)
 		}
 
-		// Check if we should retry based on status code
-		if h.shouldRetryStatus(resp.StatusCode) {
-			lastErr = h.createErrorFromResponse(resp)
-			h.logRetry(attempt, maxRetries, lastErr)
-			continue
-		}
-
 		return resp, nil
 	}
 
@@ -386,18 +379,6 @@ func (h *HTTPClient) isRetryableError(err error) bool {
 	}
 
 	return false
-}
-
-// shouldRetryStatus determines if a status code should trigger a retry
-func (h *HTTPClient) shouldRetryStatus(statusCode int) bool {
-	switch statusCode {
-	case 429: // Too Many Requests
-		return true
-	case 500, 502, 503, 504: // Server errors
-		return true
-	default:
-		return false
-	}
 }
 
 // logRequest logs the outgoing HTTP request

--- a/http_client.go
+++ b/http_client.go
@@ -334,9 +334,10 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 		resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 	}
 
-	// Set IsTransient on the base error
+	// Set IsTransient and HTTPStatusCode on the base error
 	if base := extractBaseError(resultErr); base != nil {
 		base.IsTransient = isTransient
+		base.HTTPStatusCode = resp.StatusCode
 	}
 
 	return resultErr
@@ -371,10 +372,15 @@ func (h *HTTPClient) isRetryableError(err error) bool {
 		return netErr.Temporary
 	}
 
-	// Some API errors are retry-able (5xx status codes)
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
-		return apiErr.Code >= 500 && apiErr.Code < 600
+	// Check base error for transient flag or 5xx HTTP status
+	baseErr := extractBaseError(err)
+	if baseErr != nil {
+		if baseErr.IsTransient {
+			return true
+		}
+		if baseErr.HTTPStatusCode >= 500 && baseErr.HTTPStatusCode < 600 {
+			return true
+		}
 	}
 
 	return false

--- a/http_client.go
+++ b/http_client.go
@@ -355,7 +355,7 @@ func (h *HTTPClient) isRetryableError(err error) bool {
 	// Temporary network errors are retry-able
 	var netErr *NetworkError
 	if errors.As(err, &netErr) {
-		return netErr.Temporary
+		return netErr.Temporary || netErr.IsTransient
 	}
 
 	// Check base error for transient flag or 5xx HTTP status

--- a/http_client.go
+++ b/http_client.go
@@ -270,19 +270,22 @@ func (h *HTTPClient) parseRateLimitHeaders(headers http.Header) *RateLimitInfo {
 func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 	var apiErr struct {
 		Error struct {
-			Message string `json:"message"`
-			Type    string `json:"type"`
-			Code    int    `json:"code"`
+			Message     string `json:"message"`
+			Type        string `json:"type"`
+			Code        int    `json:"code"`
+			IsTransient bool   `json:"is_transient"`
 		} `json:"error"`
 	}
 
 	// Try to parse error response
 	message := fmt.Sprintf("HTTP %d", resp.StatusCode)
 	errorCode := resp.StatusCode
+	isTransient := false
 
 	if len(resp.Body) > 0 {
 		if err := json.Unmarshal(resp.Body, &apiErr); err == nil && apiErr.Error.Message != "" {
 			message = apiErr.Error.Message
+			isTransient = apiErr.Error.IsTransient
 			if apiErr.Error.Code != 0 {
 				errorCode = apiErr.Error.Code
 			}
@@ -295,11 +298,12 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 	}
 
 	// Create specific error types based on status code
+	var resultErr error
 	switch resp.StatusCode {
 	case 401:
-		return NewAuthenticationError(errorCode, message, details)
+		resultErr = NewAuthenticationError(errorCode, message, details)
 	case 403:
-		return NewAuthenticationError(errorCode, message, details)
+		resultErr = NewAuthenticationError(errorCode, message, details)
 	case 429:
 		retryAfter := time.Duration(0)
 		resetTime := time.Time{}
@@ -321,14 +325,21 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 			h.rateLimiter.MarkRateLimited(resetTime)
 		}
 
-		return NewRateLimitError(errorCode, message, details, retryAfter)
+		resultErr = NewRateLimitError(errorCode, message, details, retryAfter)
 	case 400, 422:
-		return NewValidationError(errorCode, message, details, "")
+		resultErr = NewValidationError(errorCode, message, details, "")
 	case 500, 502, 503, 504:
-		return NewAPIError(errorCode, message, details, resp.RequestID)
+		resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 	default:
-		return NewAPIError(errorCode, message, details, resp.RequestID)
+		resultErr = NewAPIError(errorCode, message, details, resp.RequestID)
 	}
+
+	// Set IsTransient on the base error
+	if base := extractBaseError(resultErr); base != nil {
+		base.IsTransient = isTransient
+	}
+
+	return resultErr
 }
 
 // wrapNetworkError wraps network errors with appropriate error types

--- a/posts_create.go
+++ b/posts_create.go
@@ -157,11 +157,14 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 		}(i, childID)
 	}
 
-	// Collect all results, then report the lowest-indexed failure for deterministic behavior
+	// Collect all results; cancel siblings as soon as any failure is seen
 	errs := make([]error, len(content.Children))
 	for range content.Children {
 		result := <-results
 		errs[result.index] = result.err
+		if result.err != nil {
+			cancelChildren()
+		}
 	}
 	// Report the first real failure, skipping cancellation side-effects from siblings
 	for i, err := range errs {

--- a/posts_create.go
+++ b/posts_create.go
@@ -156,10 +156,15 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 		}(i, childID)
 	}
 
+	// Collect all results, then report the lowest-indexed failure for deterministic behavior
+	errs := make([]error, len(content.Children))
 	for range content.Children {
 		result := <-results
-		if result.err != nil {
-			return nil, fmt.Errorf("child container %d (%s) not ready: %w", result.index+1, result.id, result.err)
+		errs[result.index] = result.err
+	}
+	for i, err := range errs {
+		if err != nil {
+			return nil, fmt.Errorf("child container %d (%s) not ready: %w", i+1, content.Children[i], err)
 		}
 	}
 

--- a/posts_create.go
+++ b/posts_create.go
@@ -610,13 +610,6 @@ func (c *Client) waitForContainerReady(ctx context.Context, containerID Containe
 			return fmt.Errorf("container processing failed with error status")
 		case ContainerStatusExpired:
 			return fmt.Errorf("container expired before it could be published")
-		case ContainerStatusInProgress, ContainerStatusPublished:
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(pollInterval):
-				continue
-			}
 		default:
 			select {
 			case <-ctx.Done():

--- a/posts_create.go
+++ b/posts_create.go
@@ -3,6 +3,7 @@ package threads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -156,16 +157,19 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 		}(i, childID)
 	}
 
-	// Collect all results, then report the lowest-indexed failure for deterministic behavior.
-	// Cancel eagerly on first error so remaining goroutines stop polling.
+	// Collect all results, then report the lowest-indexed failure for deterministic behavior
 	errs := make([]error, len(content.Children))
 	for range content.Children {
 		result := <-results
 		errs[result.index] = result.err
-		if result.err != nil {
-			cancelChildren()
+	}
+	// Report the first real failure, skipping cancellation side-effects from siblings
+	for i, err := range errs {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("child container %d (%s) not ready: %w", i+1, content.Children[i], err)
 		}
 	}
+	// Fallback: if only cancellation errors exist, report the first one
 	for i, err := range errs {
 		if err != nil {
 			return nil, fmt.Errorf("child container %d (%s) not ready: %w", i+1, content.Children[i], err)

--- a/posts_create.go
+++ b/posts_create.go
@@ -156,11 +156,15 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 		}(i, childID)
 	}
 
-	// Collect all results, then report the lowest-indexed failure for deterministic behavior
+	// Collect all results, then report the lowest-indexed failure for deterministic behavior.
+	// Cancel eagerly on first error so remaining goroutines stop polling.
 	errs := make([]error, len(content.Children))
 	for range content.Children {
 		result := <-results
 		errs[result.index] = result.err
+		if result.err != nil {
+			cancelChildren()
+		}
 	}
 	for i, err := range errs {
 		if err != nil {

--- a/posts_create.go
+++ b/posts_create.go
@@ -146,10 +146,12 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 		err   error
 	}
 	results := make(chan childResult, len(content.Children))
+	childCtx, cancelChildren := context.WithCancel(ctx)
+	defer cancelChildren()
 
 	for i, childID := range content.Children {
 		go func(idx int, cID string) {
-			err := c.waitForContainerReady(ctx, ContainerID(cID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval)
+			err := c.waitForContainerReady(childCtx, ContainerID(cID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval)
 			results <- childResult{index: idx, id: cID, err: err}
 		}(i, childID)
 	}

--- a/posts_create.go
+++ b/posts_create.go
@@ -138,11 +138,26 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 		return nil, err
 	}
 
-	// Wait for all child containers to be ready before creating the carousel container
+	// Wait for all child containers to be ready in parallel
 	// The Threads API requires child containers to be in FINISHED status
+	type childResult struct {
+		index int
+		id    string
+		err   error
+	}
+	results := make(chan childResult, len(content.Children))
+
 	for i, childID := range content.Children {
-		if err := c.waitForContainerReady(ctx, ContainerID(childID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval); err != nil {
-			return nil, fmt.Errorf("child container %d (%s) not ready: %w", i+1, childID, err)
+		go func(idx int, cID string) {
+			err := c.waitForContainerReady(ctx, ContainerID(cID), DefaultContainerPollMaxAttempts, DefaultContainerPollInterval)
+			results <- childResult{index: idx, id: cID, err: err}
+		}(i, childID)
+	}
+
+	for range content.Children {
+		result := <-results
+		if result.err != nil {
+			return nil, fmt.Errorf("child container %d (%s) not ready: %w", result.index+1, result.id, result.err)
 		}
 	}
 
@@ -576,7 +591,8 @@ func (c *Client) GetContainerStatus(ctx context.Context, containerID ContainerID
 }
 
 // waitForContainerReady polls the container status until it's ready to be published
-// Returns an error if the container fails or times out
+// Returns an error if the container fails or times out. Respects context cancellation
+// by using select with ctx.Done() instead of bare time.Sleep.
 func (c *Client) waitForContainerReady(ctx context.Context, containerID ContainerID, maxAttempts int, pollInterval time.Duration) error {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		status, err := c.GetContainerStatus(ctx, containerID)
@@ -586,7 +602,6 @@ func (c *Client) waitForContainerReady(ctx context.Context, containerID Containe
 
 		switch status.Status {
 		case ContainerStatusFinished:
-			// Container is ready to be published
 			return nil
 		case ContainerStatusError:
 			if status.ErrorMessage != "" {
@@ -596,13 +611,19 @@ func (c *Client) waitForContainerReady(ctx context.Context, containerID Containe
 		case ContainerStatusExpired:
 			return fmt.Errorf("container expired before it could be published")
 		case ContainerStatusInProgress, ContainerStatusPublished:
-			// Still processing or already published, wait and retry
-			time.Sleep(pollInterval)
-			continue
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pollInterval):
+				continue
+			}
 		default:
-			// Unknown status, wait and retry
-			time.Sleep(pollInterval)
-			continue
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pollInterval):
+				continue
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR improves the retry/error handling infrastructure and container lifecycle management in the Threads API client:

- **Parse `is_transient` and `error_subcode` from Meta API error responses** — all typed errors (`APIError`, `ValidationError`, `AuthenticationError`, etc.) now carry `IsTransient`, `HTTPStatusCode`, and `ErrorSubcode` fields on the shared `BaseError`, enabling richer error inspection by callers.
- **Fix retry decisions to use HTTP status code instead of API error code** — previously, `isRetryableError` compared `apiErr.Code` (the Meta error code, e.g. `2`) against the 500-599 range, which never matched. Now retry logic checks `baseErr.HTTPStatusCode` and the `IsTransient` flag, so 5xx responses and transient errors are correctly retried.
- **Remove dead `shouldRetryStatus` code path** — `executeRequest` already returns an error for HTTP >= 400, so the status-code check in `Do()` was unreachable. Retry for 429/5xx is now handled via `isRetryableError` on the error path.
- **Add `IsTransientError()` public helper** — follows the existing `IsAuthenticationError`/`IsRateLimitError` pattern, letting callers check if an error is transient without type-switching.
- **Parallelize child container readiness checks in carousel creation** — child containers are now polled concurrently via goroutines instead of sequentially, reducing carousel creation latency proportionally to the number of children.
- **Respect context cancellation in `waitForContainerReady`** — replaced bare `time.Sleep` with `select` on `ctx.Done()` / `time.After`, so timeouts and cancellation propagate correctly.
- **Extract `setErrorMetadata` helper and simplify switch cases** — DRYs up the repeated `extractBaseError` + field-setting pattern, merges identical 401/403 and 5xx/default switch arms, and removes the redundant InProgress/Published case in `waitForContainerReady`.

## Test plan

- [x] `TestCreateErrorFromResponseParsesIsTransient` — verifies `is_transient` is parsed from JSON
- [x] `TestCreateErrorFromResponseParsesErrorSubcode` — verifies `error_subcode` is parsed
- [x] `TestIsRetryableErrorWithTransientAPIError` — validates retry for transient, 5xx, and non-retryable errors
- [x] `TestIsTransientErrorHelper` — validates the public `IsTransientError()` helper
- [x] `TestErrorIsTransient` / `TestErrorSubcode` — field-level checks on error types
- [x] `TestWaitForContainerReadyRespectsContext` — confirms context timeout is honored
- [x] All existing tests pass (`go test ./...`)