### PR TITLE
fix: use unicode character count for text length validation

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -166,6 +166,24 @@ func TestValidation(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error for text too long")
 		}
+
+		// Test CJK text within character limit (500 CJK chars = 1500 bytes,
+		// but should count as 500 characters, not 1500)
+		cjkText := ""
+		for i := 0; i < MaxTextLength; i++ {
+			cjkText += "你"
+		}
+		err = validator.ValidateTextLength(cjkText, "Text")
+		if err != nil {
+			t.Errorf("Expected no error for %d CJK characters, got: %v", MaxTextLength, err)
+		}
+
+		// Test CJK text exceeding character limit (501 CJK chars)
+		cjkText += "你"
+		err = validator.ValidateTextLength(cjkText, "Text")
+		if err == nil {
+			t.Error("Expected error for CJK text exceeding character limit")
+		}
 	})
 
 	t.Run("ValidateTopicTag", func(t *testing.T) {

--- a/validation.go
+++ b/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // Validator provides common validation methods
@@ -22,9 +23,12 @@ func (v *Validator) ValidatePostContent(content interface{}, _ int) error {
 	return nil
 }
 
-// ValidateTextLength validates text doesn't exceed maximum length
+// ValidateTextLength validates text doesn't exceed maximum length.
+// The Threads API limits text posts to 500 characters (Unicode code points),
+// not 500 bytes. Using utf8.RuneCountInString ensures CJK and other
+// multi-byte characters are correctly counted as 1 character each.
 func (v *Validator) ValidateTextLength(text string, fieldName string) error {
-	if len(text) > MaxTextLength {
+	if utf8.RuneCountInString(text) > MaxTextLength {
 		return NewValidationError(400,
 			fmt.Sprintf("%s too long", fieldName),
 			fmt.Sprintf("%s is limited to %d characters", fieldName, MaxTextLength),

--- a/validation.go
+++ b/validation.go
@@ -89,10 +89,10 @@ func (v *Validator) ValidateTextAttachment(textAttachment *TextAttachment) error
 			"text_attachment.plaintext")
 	}
 
-	if len(textAttachment.Plaintext) > MaxTextAttachmentLength {
+	if utf8.RuneCountInString(textAttachment.Plaintext) > MaxTextAttachmentLength {
 		return NewValidationError(400,
 			"Text attachment plaintext too long",
-			fmt.Sprintf("Text attachment plaintext is limited to %d characters (currently %d)", MaxTextAttachmentLength, len(textAttachment.Plaintext)),
+			fmt.Sprintf("Text attachment plaintext is limited to %d characters (currently %d)", MaxTextAttachmentLength, utf8.RuneCountInString(textAttachment.Plaintext)),
 			"text_attachment.plaintext")
 	}
 


### PR DESCRIPTION
## Summary

`ValidateTextLength` currently uses `len(text)` which counts UTF-8 bytes, not characters. This causes CJK (Chinese/Japanese/Korean) text to be incorrectly rejected even when it's within the 500-character limit.

For example, 346 Chinese characters = 1002 UTF-8 bytes, which exceeds `MaxTextLength` (500) when measured in bytes, but is well within the 500-character limit defined by the Threads API.

### Changes

- Changed `len(text)` to `utf8.RuneCountInString(text)` in `ValidateTextLength` to correctly count Unicode characters
- Added test case for CJK text validation

### Before (bug)
```
"你" × 346 → len() = 1002 → rejected ❌ (should be allowed)
```

### After (fix)
```
"你" × 346 → utf8.RuneCountInString() = 346 → allowed ✅
"你" × 501 → utf8.RuneCountInString() = 501 → rejected ✅
```

### Reference
- [Threads API docs](https://developers.facebook.com/docs/threads/posts/): "Text posts are limited to 500 characters"