### PR TITLE
fix: restrict GITHUB_TOKEN permissions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,9 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: contents: read` to both CI and Integration Tests workflows
- Restricts `GITHUB_TOKEN` from broad default permissions to minimum required scope
- Resolves [CodeQL alert #8](https://github.com/tirthpatell/threads-go/security/code-scanning/8)

## Test plan
- [x] CI workflow runs successfully with restricted permissions
- [x] Integration tests workflow runs successfully with restricted permissions