### PR TITLE
test: increase coverage to 93.6% and add Codecov for awesome-go listing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,11 @@ jobs:
         valColorRange: ${{ steps.coverage.outputs.percentage }}
         minColorRange: 40
         maxColorRange: 90
+
+    - name: Upload coverage to Codecov
+      if: matrix.go-version == '1.24'
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage.out
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/tirthpatell/threads-go.svg)](https://pkg.go.dev/github.com/tirthpatell/threads-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tirthpatell/threads-go)](https://goreportcard.com/report/github.com/tirthpatell/threads-go)
+[![CI](https://github.com/tirthpatell/threads-go/actions/workflows/ci.yml/badge.svg)](https://github.com/tirthpatell/threads-go/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/tirthpatell/threads-go/branch/main/graph/badge.svg)](https://codecov.io/gh/tirthpatell/threads-go)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/tirthpatell/2c608589294aed9aa900256daeec0fd4/raw/coverage.json)](https://github.com/tirthpatell/threads-go/actions)
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -72,6 +72,60 @@ func TestExchangeCodeForToken_EmptyCode(t *testing.T) {
 	}
 }
 
+func TestExchangeCodeForToken_ServerError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"error":{"message":"Invalid code","type":"OAuthException","code":100}}`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	config.BaseURL = server.URL
+
+	client, _ := NewClient(config)
+	err := client.ExchangeCodeForToken(context.Background(), "bad_code")
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+
+func TestExchangeCodeForToken_NoExpiresIn(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"bearer","user_id":123}`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	config.BaseURL = server.URL
+
+	client, _ := NewClient(config)
+	err := client.ExchangeCodeForToken(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ti := client.GetTokenInfo()
+	if ti.AccessToken != "tok" {
+		t.Errorf("expected tok, got %s", ti.AccessToken)
+	}
+}
+
 func TestGetLongLivedToken_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{
 		"access_token": "long_lived_token",
@@ -146,6 +200,274 @@ func TestDebugToken_Success(t *testing.T) {
 	}
 }
 
+func TestDebugToken_NoToken(t *testing.T) {
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	client, _ := NewClient(config)
+
+	_, err := client.DebugToken(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error when no access token")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestDebugToken_EmptyInputToken(t *testing.T) {
+	// When inputToken is empty, should use client's own access token
+	client := testClient(t, jsonHandler(200, `{
+		"data": {"type":"USER","is_valid":true,"expires_at":1735689600,"issued_at":1735603200,"user_id":"12345","scopes":["threads_basic"]}
+	}`))
+
+	resp, err := client.DebugToken(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Data.IsValid {
+		t.Error("expected valid token")
+	}
+}
+
+func TestDebugToken_ServerError(t *testing.T) {
+	client := testClient(t, jsonHandler(401, `{"error":{"message":"invalid token","type":"OAuthException","code":190}}`))
+	_, err := client.DebugToken(context.Background(), "bad-token")
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestHandleTokenError_AuthError(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.handleTokenError(401, []byte(`{"error":{"message":"token expired","type":"auth_error","code":190}}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestHandleTokenError_RateLimitError(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.handleTokenError(429, []byte(`{"error":{"message":"rate limited","type":"rate_limit","code":429}}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got %T", err)
+	}
+}
+
+func TestHandleTokenError_ValidationError(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.handleTokenError(400, []byte(`{"error":{"message":"bad request","type":"validation","code":400}}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestHandleTokenError_GenericError(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.handleTokenError(500, []byte(`{"error":{"message":"server error","type":"server","code":500}}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsAPIError(err) {
+		t.Errorf("expected APIError, got %T", err)
+	}
+}
+
+func TestHandleTokenError_UnparseableBody(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.handleTokenError(401, []byte(`not json at all`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError for unparseable body, got %T", err)
+	}
+}
+
+func TestGetAccessToken(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	token := client.GetAccessToken()
+	if token != "test-access-token" {
+		t.Errorf("expected test-access-token, got %s", token)
+	}
+}
+
+func TestLoadTokenFromStorage_Success(t *testing.T) {
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+
+	// Pre-store a valid token
+	storage := &MemoryTokenStorage{}
+	_ = storage.Store(&TokenInfo{
+		AccessToken: "stored_token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+		UserID:      "12345",
+		CreatedAt:   time.Now(),
+	})
+	config.TokenStorage = storage
+
+	client, _ := NewClient(config)
+	err := client.LoadTokenFromStorage()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.GetAccessToken() != "stored_token" {
+		t.Errorf("expected stored_token, got %s", client.GetAccessToken())
+	}
+}
+
+func TestLoadTokenFromStorage_ExpiredToken(t *testing.T) {
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+
+	storage := &MemoryTokenStorage{}
+	_ = storage.Store(&TokenInfo{
+		AccessToken: "expired_token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(-time.Hour), // expired
+		UserID:      "12345",
+		CreatedAt:   time.Now().Add(-2 * time.Hour),
+	})
+	config.TokenStorage = storage
+
+	client, _ := NewClient(config)
+	err := client.LoadTokenFromStorage()
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestLoadTokenFromStorage_NoToken(t *testing.T) {
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+
+	// Fresh storage with no token
+	config.TokenStorage = &MemoryTokenStorage{}
+
+	client, _ := NewClient(config)
+	err := client.LoadTokenFromStorage()
+	if err == nil {
+		t.Fatal("expected error when no stored token")
+	}
+}
+
+func TestGetTokenDebugInfo_WithToken(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	info := client.GetTokenDebugInfo()
+
+	if hasToken, ok := info["has_token"].(bool); !ok || !hasToken {
+		t.Error("expected has_token to be true")
+	}
+	if isAuth, ok := info["is_authenticated"].(bool); !ok || !isAuth {
+		t.Error("expected is_authenticated to be true")
+	}
+	if _, ok := info["token_type"]; !ok {
+		t.Error("expected token_type in debug info")
+	}
+	if _, ok := info["user_id"]; !ok {
+		t.Error("expected user_id in debug info")
+	}
+	if _, ok := info["expires_at"]; !ok {
+		t.Error("expected expires_at in debug info")
+	}
+	if _, ok := info["time_until_expiry"]; !ok {
+		t.Error("expected time_until_expiry in debug info")
+	}
+	if _, ok := info["expires_in_hours"]; !ok {
+		t.Error("expected expires_in_hours in debug info")
+	}
+	if _, ok := info["expires_in_days"]; !ok {
+		t.Error("expected expires_in_days in debug info")
+	}
+}
+
+func TestGetTokenDebugInfo_NoToken(t *testing.T) {
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	client, _ := NewClient(config)
+	info := client.GetTokenDebugInfo()
+
+	if hasToken, ok := info["has_token"].(bool); !ok || hasToken {
+		t.Error("expected has_token to be false")
+	}
+	if _, ok := info["token_type"]; ok {
+		t.Error("expected no token_type without a token")
+	}
+}
+
+func TestSetTokenFromDebugInfo_Success(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	debugResp := &DebugTokenResponse{}
+	debugResp.Data.IsValid = true
+	debugResp.Data.ExpiresAt = time.Now().Add(24 * time.Hour).Unix()
+	debugResp.Data.IssuedAt = time.Now().Unix()
+	debugResp.Data.UserID = "99999"
+	debugResp.Data.Scopes = []string{"threads_basic"}
+
+	err := client.SetTokenFromDebugInfo("new_token_abc", debugResp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.GetAccessToken() != "new_token_abc" {
+		t.Errorf("expected new_token_abc, got %s", client.GetAccessToken())
+	}
+	ti := client.GetTokenInfo()
+	if ti.UserID != "99999" {
+		t.Errorf("expected user ID 99999, got %s", ti.UserID)
+	}
+}
+
+func TestSetTokenFromDebugInfo_NilResponse(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.SetTokenFromDebugInfo("token", nil)
+	if err == nil {
+		t.Fatal("expected error for nil debug response")
+	}
+}
+
+func TestSetTokenFromDebugInfo_InvalidToken(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	debugResp := &DebugTokenResponse{}
+	debugResp.Data.IsValid = false
+
+	err := client.SetTokenFromDebugInfo("token", debugResp)
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
 func TestGetAuthURL_ContainsRequiredParams(t *testing.T) {
 	config := &Config{
 		ClientID:     "my-app-id",
@@ -163,6 +485,174 @@ func TestGetAuthURL_ContainsRequiredParams(t *testing.T) {
 		if !strings.Contains(authURL, param) {
 			t.Errorf("expected auth URL to contain %q, got %s", param, authURL)
 		}
+	}
+}
+
+func TestGetAuthURL_DefaultScopes(t *testing.T) {
+	config := &Config{
+		ClientID:     "my-app-id",
+		ClientSecret: "secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	client, _ := NewClient(config)
+
+	authURL := client.GetAuthURL(nil)
+	if !strings.Contains(authURL, "threads_basic") {
+		t.Error("expected default scope threads_basic in auth URL")
+	}
+}
+
+func TestExchangeCodeForToken_WithLogger(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"bearer","expires_in":3600,"user_id":123}`))
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+		Logger:       &noopLogger{},
+	}
+	config.SetDefaults()
+	config.BaseURL = server.URL
+
+	client, _ := NewClient(config)
+	err := client.ExchangeCodeForToken(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetLongLivedToken_NoToken(t *testing.T) {
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	client, _ := NewClient(config)
+
+	err := client.GetLongLivedToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error when no token")
+	}
+}
+
+func TestGetLongLivedToken_ServerError(t *testing.T) {
+	client := testClient(t, jsonHandler(401, `{"error":{"message":"invalid","type":"OAuthException","code":190}}`))
+	err := client.GetLongLivedToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestGetLongLivedToken_NoExpiresIn(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"access_token":"ll_tok","token_type":"bearer"}`))
+	err := client.GetLongLivedToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ti := client.GetTokenInfo()
+	if ti.AccessToken != "ll_tok" {
+		t.Errorf("expected ll_tok, got %s", ti.AccessToken)
+	}
+}
+
+func TestGetLongLivedToken_WithLogger(t *testing.T) {
+	handler := jsonHandler(200, `{"access_token":"ll","token_type":"bearer","expires_in":5184000}`)
+	config := testClientConfig(t, handler)
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+	err := client.GetLongLivedToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefreshToken_ServerError(t *testing.T) {
+	client := testClient(t, jsonHandler(401, `{"error":{"message":"invalid","type":"OAuthException","code":190}}`))
+	err := client.RefreshToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestRefreshToken_NoExpiresIn(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"access_token":"ref_tok","token_type":"bearer"}`))
+	err := client.RefreshToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefreshToken_WithLogger(t *testing.T) {
+	handler := jsonHandler(200, `{"access_token":"ref","token_type":"bearer","expires_in":5184000}`)
+	config := testClientConfig(t, handler)
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+	err := client.RefreshToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadTokenFromStorage_WithLogger(t *testing.T) {
+	storage := &MemoryTokenStorage{}
+	_ = storage.Store(&TokenInfo{
+		AccessToken: "stored",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+		UserID:      "12345",
+		CreatedAt:   time.Now(),
+	})
+
+	config := &Config{
+		ClientID:     "test-id",
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://example.com/callback",
+		Logger:       &noopLogger{},
+		TokenStorage: storage,
+	}
+	config.SetDefaults()
+
+	client, _ := NewClient(config)
+	err := client.LoadTokenFromStorage()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDebugToken_WithLogger(t *testing.T) {
+	handler := jsonHandler(200, `{"data":{"type":"USER","is_valid":true,"expires_at":1735689600,"issued_at":1735603200,"user_id":"12345","scopes":["threads_basic"]}}`)
+	config := testClientConfig(t, handler)
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+	_, err := client.DebugToken(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetTokenFromDebugInfo_WithLogger(t *testing.T) {
+	handler := jsonHandler(200, `{}`)
+	config := testClientConfig(t, handler)
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+
+	debugResp := &DebugTokenResponse{}
+	debugResp.Data.IsValid = true
+	debugResp.Data.ExpiresAt = time.Now().Add(24 * time.Hour).Unix()
+	debugResp.Data.IssuedAt = time.Now().Unix()
+	debugResp.Data.UserID = "99999"
+
+	err := client.SetTokenFromDebugInfo("tok", debugResp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1504,7 +1504,7 @@ func TestTestAPICall(t *testing.T) {
 		}
 	})
 
-	t.Run("default method uses GET", func(t *testing.T) {
+	t.Run("unsupported method falls back to GET", func(t *testing.T) {
 		client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != "GET" {
 				t.Errorf("Expected GET for default, got %s", r.Method)

--- a/client_test.go
+++ b/client_test.go
@@ -775,6 +775,274 @@ func TestCreateErrorFromResponseParsesErrorSubcode(t *testing.T) {
 	}
 }
 
+func TestContainerBuilderSetIsCarouselItem(t *testing.T) {
+	t.Run("true sets param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetIsCarouselItem(true).Build()
+		if params.Get("is_carousel_item") != "true" {
+			t.Errorf("Expected is_carousel_item='true', got %q", params.Get("is_carousel_item"))
+		}
+	})
+
+	t.Run("false does not set param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetIsCarouselItem(false).Build()
+		if params.Get("is_carousel_item") != "" {
+			t.Errorf("Expected empty is_carousel_item, got %q", params.Get("is_carousel_item"))
+		}
+	})
+}
+
+func TestContainerBuilderSetQuotePostID(t *testing.T) {
+	t.Run("non-empty sets param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetQuotePostID("12345").Build()
+		if params.Get("quote_post_id") != "12345" {
+			t.Errorf("Expected quote_post_id='12345', got %q", params.Get("quote_post_id"))
+		}
+	})
+
+	t.Run("empty does not set param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetQuotePostID("").Build()
+		if params.Get("quote_post_id") != "" {
+			t.Errorf("Expected empty quote_post_id, got %q", params.Get("quote_post_id"))
+		}
+	})
+}
+
+func TestContainerBuilderSetPollAttachment(t *testing.T) {
+	t.Run("valid poll", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		poll := &PollAttachment{
+			OptionA: "Yes",
+			OptionB: "No",
+		}
+		params := builder.SetPollAttachment(poll).Build()
+		pollParam := params.Get("poll_attachment")
+		if pollParam == "" {
+			t.Fatal("Expected poll_attachment to be set")
+		}
+		// Should contain the options
+		if !strings.Contains(pollParam, "Yes") || !strings.Contains(pollParam, "No") {
+			t.Errorf("Expected poll_attachment to contain options, got %q", pollParam)
+		}
+	})
+
+	t.Run("nil poll", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetPollAttachment(nil).Build()
+		if params.Get("poll_attachment") != "" {
+			t.Errorf("Expected empty poll_attachment for nil, got %q", params.Get("poll_attachment"))
+		}
+	})
+}
+
+func TestContainerBuilderSetTextEntities(t *testing.T) {
+	t.Run("valid entities", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		entities := []TextEntity{
+			{EntityType: "SPOILER", Offset: 0, Length: 5},
+			{EntityType: "SPOILER", Offset: 10, Length: 3},
+		}
+		params := builder.SetTextEntities(entities).Build()
+		entitiesParam := params.Get("text_entities")
+		if entitiesParam == "" {
+			t.Fatal("Expected text_entities to be set")
+		}
+		if !strings.Contains(entitiesParam, "SPOILER") {
+			t.Errorf("Expected text_entities to contain SPOILER, got %q", entitiesParam)
+		}
+	})
+
+	t.Run("empty entities", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetTextEntities(nil).Build()
+		if params.Get("text_entities") != "" {
+			t.Errorf("Expected empty text_entities for nil, got %q", params.Get("text_entities"))
+		}
+	})
+}
+
+func TestContainerBuilderSetTextAttachment(t *testing.T) {
+	t.Run("valid attachment", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		attachment := &TextAttachment{
+			Plaintext: "Long form content here",
+		}
+		params := builder.SetTextAttachment(attachment).Build()
+		attachmentParam := params.Get("text_attachment")
+		if attachmentParam == "" {
+			t.Fatal("Expected text_attachment to be set")
+		}
+		if !strings.Contains(attachmentParam, "Long form content here") {
+			t.Errorf("Expected text_attachment to contain text, got %q", attachmentParam)
+		}
+	})
+
+	t.Run("nil attachment", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetTextAttachment(nil).Build()
+		if params.Get("text_attachment") != "" {
+			t.Errorf("Expected empty text_attachment for nil, got %q", params.Get("text_attachment"))
+		}
+	})
+}
+
+func TestContainerBuilderSetLinkAttachment(t *testing.T) {
+	t.Run("non-empty link", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetLinkAttachment("https://example.com").Build()
+		if params.Get("link_attachment") != "https://example.com" {
+			t.Errorf("Expected link_attachment='https://example.com', got %q", params.Get("link_attachment"))
+		}
+	})
+
+	t.Run("empty link", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetLinkAttachment("").Build()
+		if params.Get("link_attachment") != "" {
+			t.Errorf("Expected empty link_attachment, got %q", params.Get("link_attachment"))
+		}
+	})
+}
+
+func TestContainerBuilderSetAllowlistedCountryCodes(t *testing.T) {
+	t.Run("with codes", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetAllowlistedCountryCodes([]string{"US", "CA", "GB"}).Build()
+		codes := params["allowlisted_country_codes"]
+		if len(codes) != 3 {
+			t.Errorf("Expected 3 country codes, got %d", len(codes))
+		}
+	})
+
+	t.Run("empty codes", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetAllowlistedCountryCodes(nil).Build()
+		codes := params["allowlisted_country_codes"]
+		if len(codes) != 0 {
+			t.Errorf("Expected 0 country codes, got %d", len(codes))
+		}
+	})
+}
+
+func TestContainerBuilderSetAltText(t *testing.T) {
+	t.Run("non-empty alt text", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetAltText("A photo of a sunset").Build()
+		if params.Get("alt_text") != "A photo of a sunset" {
+			t.Errorf("Expected alt_text='A photo of a sunset', got %q", params.Get("alt_text"))
+		}
+	})
+
+	t.Run("empty alt text", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetAltText("").Build()
+		if params.Get("alt_text") != "" {
+			t.Errorf("Expected empty alt_text, got %q", params.Get("alt_text"))
+		}
+	})
+}
+
+func TestContainerBuilderSetReplyTo(t *testing.T) {
+	t.Run("non-empty reply to", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetReplyTo("post-123").Build()
+		if params.Get("reply_to_id") != "post-123" {
+			t.Errorf("Expected reply_to_id='post-123', got %q", params.Get("reply_to_id"))
+		}
+	})
+
+	t.Run("empty reply to", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetReplyTo("").Build()
+		if params.Get("reply_to_id") != "" {
+			t.Errorf("Expected empty reply_to_id, got %q", params.Get("reply_to_id"))
+		}
+	})
+}
+
+func TestContainerBuilderSetTopicTag(t *testing.T) {
+	t.Run("non-empty topic tag", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetTopicTag("golang").Build()
+		if params.Get("topic_tag") != "golang" {
+			t.Errorf("Expected topic_tag='golang', got %q", params.Get("topic_tag"))
+		}
+	})
+
+	t.Run("empty topic tag", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetTopicTag("").Build()
+		if params.Get("topic_tag") != "" {
+			t.Errorf("Expected empty topic_tag, got %q", params.Get("topic_tag"))
+		}
+	})
+}
+
+func TestContainerBuilderSetLocationID(t *testing.T) {
+	t.Run("non-empty location ID", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetLocationID("loc-456").Build()
+		if params.Get("location_id") != "loc-456" {
+			t.Errorf("Expected location_id='loc-456', got %q", params.Get("location_id"))
+		}
+	})
+
+	t.Run("empty location ID", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetLocationID("").Build()
+		if params.Get("location_id") != "" {
+			t.Errorf("Expected empty location_id, got %q", params.Get("location_id"))
+		}
+	})
+}
+
+func TestContainerBuilderSetIsSpoilerMedia(t *testing.T) {
+	t.Run("true sets param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetIsSpoilerMedia(true).Build()
+		if params.Get("is_spoiler_media") != "true" {
+			t.Errorf("Expected is_spoiler_media='true', got %q", params.Get("is_spoiler_media"))
+		}
+	})
+
+	t.Run("false does not set param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetIsSpoilerMedia(false).Build()
+		if params.Get("is_spoiler_media") != "" {
+			t.Errorf("Expected empty is_spoiler_media, got %q", params.Get("is_spoiler_media"))
+		}
+	})
+}
+
+func TestContainerBuilderSetIsGhostPost(t *testing.T) {
+	t.Run("true sets param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetIsGhostPost(true).Build()
+		if params.Get("is_ghost_post") != "true" {
+			t.Errorf("Expected is_ghost_post='true', got %q", params.Get("is_ghost_post"))
+		}
+	})
+
+	t.Run("false does not set param", func(t *testing.T) {
+		builder := NewContainerBuilder()
+		params := builder.SetIsGhostPost(false).Build()
+		if params.Get("is_ghost_post") != "" {
+			t.Errorf("Expected empty is_ghost_post, got %q", params.Get("is_ghost_post"))
+		}
+	})
+}
+
+func TestContainerBuilderAddChildEmpty(t *testing.T) {
+	builder := NewContainerBuilder()
+	params := builder.AddChild("").Build()
+	if params.Get("children") != "" {
+		t.Errorf("Expected empty children for empty childID, got %q", params.Get("children"))
+	}
+}
+
 func TestSearchOptionsAuthorUsername(t *testing.T) {
 	opts := &SearchOptions{
 		AuthorUsername: "testuser",
@@ -789,6 +1057,783 @@ func TestSearchOptionsAuthorUsername(t *testing.T) {
 	opts.AuthorUsername = "@testuser"
 	if opts.AuthorUsername != "@testuser" {
 		t.Errorf("Expected AuthorUsername to be '@testuser', got '%s'", opts.AuthorUsername)
+	}
+}
+
+// clearThreadsEnv sets all THREADS_* env vars to empty via t.Setenv (auto-restored on cleanup).
+func clearThreadsEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"THREADS_CLIENT_ID", "THREADS_CLIENT_SECRET", "THREADS_REDIRECT_URI",
+		"THREADS_SCOPES", "THREADS_HTTP_TIMEOUT", "THREADS_BASE_URL",
+		"THREADS_USER_AGENT", "THREADS_DEBUG", "THREADS_MAX_RETRIES",
+		"THREADS_INITIAL_DELAY", "THREADS_MAX_DELAY", "THREADS_BACKOFF_FACTOR",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestNewConfigFromEnv(t *testing.T) {
+	clearThreadsEnv(t)
+
+	t.Run("missing THREADS_CLIENT_ID", func(t *testing.T) {
+		_, err := NewConfigFromEnv()
+		if err == nil {
+			t.Fatal("Expected error for missing THREADS_CLIENT_ID")
+		}
+	})
+
+	t.Run("missing THREADS_CLIENT_SECRET", func(t *testing.T) {
+		t.Setenv("THREADS_CLIENT_ID", "test-id")
+		_, err := NewConfigFromEnv()
+		if err == nil {
+			t.Fatal("Expected error for missing THREADS_CLIENT_SECRET")
+		}
+	})
+
+	t.Run("missing THREADS_REDIRECT_URI", func(t *testing.T) {
+		t.Setenv("THREADS_CLIENT_ID", "test-id")
+		t.Setenv("THREADS_CLIENT_SECRET", "test-secret")
+		_, err := NewConfigFromEnv()
+		if err == nil {
+			t.Fatal("Expected error for missing THREADS_REDIRECT_URI")
+		}
+	})
+
+	t.Run("all required vars set", func(t *testing.T) {
+		t.Setenv("THREADS_CLIENT_ID", "env-client-id")
+		t.Setenv("THREADS_CLIENT_SECRET", "env-client-secret")
+		t.Setenv("THREADS_REDIRECT_URI", "https://example.com/callback")
+		config, err := NewConfigFromEnv()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if config.ClientID != "env-client-id" {
+			t.Errorf("Expected ClientID 'env-client-id', got %q", config.ClientID)
+		}
+		if config.ClientSecret != "env-client-secret" {
+			t.Errorf("Expected ClientSecret 'env-client-secret', got %q", config.ClientSecret)
+		}
+	})
+
+	t.Run("optional env vars", func(t *testing.T) {
+		t.Setenv("THREADS_CLIENT_ID", "env-client-id")
+		t.Setenv("THREADS_CLIENT_SECRET", "env-client-secret")
+		t.Setenv("THREADS_REDIRECT_URI", "https://example.com/callback")
+		t.Setenv("THREADS_SCOPES", "threads_basic, threads_content_publish")
+		t.Setenv("THREADS_HTTP_TIMEOUT", "60s")
+		t.Setenv("THREADS_BASE_URL", "https://custom.example.com")
+		t.Setenv("THREADS_USER_AGENT", "custom-agent/1.0")
+		t.Setenv("THREADS_DEBUG", "true")
+		t.Setenv("THREADS_MAX_RETRIES", "5")
+		t.Setenv("THREADS_INITIAL_DELAY", "2s")
+		t.Setenv("THREADS_MAX_DELAY", "60s")
+		t.Setenv("THREADS_BACKOFF_FACTOR", "3.0")
+
+		config, err := NewConfigFromEnv()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if len(config.Scopes) != 2 {
+			t.Errorf("Expected 2 scopes, got %d", len(config.Scopes))
+		}
+		if config.Scopes[0] != "threads_basic" {
+			t.Errorf("Expected first scope 'threads_basic', got %q", config.Scopes[0])
+		}
+		if config.Scopes[1] != "threads_content_publish" {
+			t.Errorf("Expected second scope 'threads_content_publish', got %q", config.Scopes[1])
+		}
+		if config.HTTPTimeout != 60*time.Second {
+			t.Errorf("Expected HTTPTimeout 60s, got %v", config.HTTPTimeout)
+		}
+		if config.BaseURL != "https://custom.example.com" {
+			t.Errorf("Expected BaseURL 'https://custom.example.com', got %q", config.BaseURL)
+		}
+		if config.UserAgent != "custom-agent/1.0" {
+			t.Errorf("Expected UserAgent 'custom-agent/1.0', got %q", config.UserAgent)
+		}
+		if !config.Debug {
+			t.Error("Expected Debug to be true")
+		}
+		if config.RetryConfig.MaxRetries != 5 {
+			t.Errorf("Expected MaxRetries 5, got %d", config.RetryConfig.MaxRetries)
+		}
+		if config.RetryConfig.InitialDelay != 2*time.Second {
+			t.Errorf("Expected InitialDelay 2s, got %v", config.RetryConfig.InitialDelay)
+		}
+		if config.RetryConfig.MaxDelay != 60*time.Second {
+			t.Errorf("Expected MaxDelay 60s, got %v", config.RetryConfig.MaxDelay)
+		}
+		if config.RetryConfig.BackoffFactor != 3.0 {
+			t.Errorf("Expected BackoffFactor 3.0, got %v", config.RetryConfig.BackoffFactor)
+		}
+	})
+}
+
+func TestNewClientFromEnv(t *testing.T) {
+	clearThreadsEnv(t)
+
+	t.Run("fails without env vars", func(t *testing.T) {
+		_, err := NewClientFromEnv()
+		if err == nil {
+			t.Fatal("Expected error when env vars are missing")
+		}
+	})
+
+	t.Run("succeeds with required env vars", func(t *testing.T) {
+		t.Setenv("THREADS_CLIENT_ID", "client-id")
+		t.Setenv("THREADS_CLIENT_SECRET", "client-secret")
+		t.Setenv("THREADS_REDIRECT_URI", "https://example.com/callback")
+		client, err := NewClientFromEnv()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if client == nil {
+			t.Fatal("Expected non-nil client")
+		}
+	})
+}
+
+func TestNewClientWithToken(t *testing.T) {
+	t.Run("empty token returns error", func(t *testing.T) {
+		_, err := NewClientWithToken("", &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+		})
+		if err == nil {
+			t.Fatal("Expected error for empty token")
+		}
+	})
+
+	t.Run("nil config returns error", func(t *testing.T) {
+		_, err := NewClientWithToken("some-token", nil)
+		if err == nil {
+			t.Fatal("Expected error for nil config")
+		}
+	})
+
+	t.Run("debug token fails returns error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(400)
+			w.Write([]byte(`{"error":{"message":"Invalid token","type":"OAuthException","code":190}}`))
+		}))
+		defer ts.Close()
+
+		config := &Config{
+			ClientID:     "test-id",
+			ClientSecret: "test-secret",
+			RedirectURI:  "https://example.com/callback",
+			BaseURL:      ts.URL,
+		}
+
+		_, err := NewClientWithToken("invalid-token", config)
+		if err == nil {
+			t.Fatal("Expected error for invalid token")
+		}
+	})
+
+	t.Run("valid token with mock server", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(`{
+				"data": {
+					"app_id": "123",
+					"type": "USER",
+					"application": "TestApp",
+					"is_valid": true,
+					"issued_at": 1700000000,
+					"expires_at": 1900000000,
+					"scopes": ["threads_basic"],
+					"user_id": "456"
+				}
+			}`))
+		}))
+		defer ts.Close()
+
+		config := &Config{
+			ClientID:     "test-id",
+			ClientSecret: "test-secret",
+			RedirectURI:  "https://example.com/callback",
+			BaseURL:      ts.URL,
+		}
+
+		client, err := NewClientWithToken("valid-token", config)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if client == nil {
+			t.Fatal("Expected non-nil client")
+		}
+		if !client.IsAuthenticated() {
+			t.Error("Expected client to be authenticated")
+		}
+	})
+}
+
+func TestValidateToken(t *testing.T) {
+	t.Run("not authenticated", func(t *testing.T) {
+		client := newBareClient(t)
+		err := client.ValidateToken()
+		if err == nil {
+			t.Fatal("Expected error for unauthenticated client")
+		}
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		client := newBareClient(t)
+		client.tokenInfo = &TokenInfo{
+			AccessToken: "expired-token",
+			ExpiresAt:   time.Now().Add(-time.Hour),
+		}
+		client.accessToken = "expired-token"
+		err := client.ValidateToken()
+		if err == nil {
+			t.Fatal("Expected error for expired token")
+		}
+	})
+
+	t.Run("valid token with mock", func(t *testing.T) {
+		client := testClient(t, jsonHandler(200, `{"id":"12345"}`))
+
+		err := client.ValidateToken()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+	})
+}
+
+func TestGetConfig(t *testing.T) {
+	client := newBareClient(t)
+
+	retrieved := client.GetConfig()
+	if retrieved == nil {
+		t.Fatal("Expected non-nil config")
+	}
+	if retrieved.ClientID == "" {
+		t.Error("Expected non-empty ClientID")
+	}
+
+	// Verify it's a copy (modifying shouldn't affect client)
+	original := client.config.ClientID
+	retrieved.ClientID = "modified"
+	if client.config.ClientID != original {
+		t.Error("GetConfig should return a copy, not a reference")
+	}
+}
+
+func TestUpdateConfig(t *testing.T) {
+	client := newBareClient(t)
+
+	t.Run("nil config returns error", func(t *testing.T) {
+		err := client.UpdateConfig(nil)
+		if err == nil {
+			t.Fatal("Expected error for nil config")
+		}
+	})
+
+	t.Run("invalid config returns error", func(t *testing.T) {
+		err := client.UpdateConfig(&Config{})
+		if err == nil {
+			t.Fatal("Expected error for empty config")
+		}
+	})
+
+	t.Run("valid config updates client", func(t *testing.T) {
+		newConfig := &Config{
+			ClientID:     "new-id",
+			ClientSecret: "new-secret",
+			RedirectURI:  "https://new.example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  60 * time.Second,
+			BaseURL:      "https://new-api.example.com",
+			RetryConfig: &RetryConfig{
+				MaxRetries:    5,
+				InitialDelay:  time.Second,
+				MaxDelay:      30 * time.Second,
+				BackoffFactor: 2.0,
+			},
+		}
+		err := client.UpdateConfig(newConfig)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if client.baseURL != "https://new-api.example.com" {
+			t.Errorf("Expected baseURL to be updated, got %q", client.baseURL)
+		}
+	})
+}
+
+func TestClone(t *testing.T) {
+	client := newBareClient(t)
+
+	cloned, err := client.Clone()
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if cloned == nil {
+		t.Fatal("Expected non-nil cloned client")
+	}
+	if cloned == client {
+		t.Error("Expected Clone to return a different instance")
+	}
+}
+
+func TestCloneWithConfig(t *testing.T) {
+	client := newBareClient(t)
+
+	newConfig := &Config{
+		ClientID:     "new-id",
+		ClientSecret: "new-secret",
+		RedirectURI:  "https://new.example.com/callback",
+		Scopes:       []string{"threads_basic"},
+		HTTPTimeout:  60 * time.Second,
+		BaseURL:      "https://new-api.example.com",
+	}
+
+	cloned, err := client.CloneWithConfig(newConfig)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if cloned == nil {
+		t.Fatal("Expected non-nil cloned client")
+	}
+}
+
+func TestGetRateLimitStatus(t *testing.T) {
+	client := newBareClient(t)
+
+	status := client.GetRateLimitStatus()
+	if status.Limit <= 0 {
+		t.Errorf("Expected positive limit, got %d", status.Limit)
+	}
+}
+
+func TestIsNearRateLimit(t *testing.T) {
+	client := newBareClient(t)
+
+	// With fresh rate limiter, should not be near limit
+	if client.IsNearRateLimit(0.9) {
+		t.Error("Expected not near rate limit with fresh limiter")
+	}
+}
+
+func TestIsRateLimited(t *testing.T) {
+	client := newBareClient(t)
+
+	if client.IsRateLimited() {
+		t.Error("Expected not rate limited with fresh limiter")
+	}
+}
+
+func TestDisableAndEnableRateLimiting(t *testing.T) {
+	client := newBareClient(t)
+
+	// Disable
+	client.DisableRateLimiting()
+	if client.rateLimiter != nil {
+		t.Error("Expected rateLimiter to be nil after disabling")
+	}
+
+	// Enable
+	client.EnableRateLimiting()
+	if client.rateLimiter == nil {
+		t.Error("Expected rateLimiter to be non-nil after enabling")
+	}
+
+	// Enable again (should be no-op since already enabled)
+	client.EnableRateLimiting()
+	if client.rateLimiter == nil {
+		t.Error("Expected rateLimiter to still be non-nil")
+	}
+}
+
+func TestWaitForRateLimit(t *testing.T) {
+	client := newBareClient(t)
+
+	// Should return immediately when not rate limited
+	ctx := context.Background()
+	err := client.WaitForRateLimit(ctx)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+}
+
+func TestTestAPICall(t *testing.T) {
+	t.Run("GET request", func(t *testing.T) {
+		client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "GET" {
+				t.Errorf("Expected GET, got %s", r.Method)
+			}
+			if r.URL.Query().Get("fields") != "id" {
+				t.Errorf("Expected fields=id, got %s", r.URL.Query().Get("fields"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(`{"id":"12345"}`))
+		}))
+
+		resp, err := client.TestAPICall("GET", "/v1.0/me", map[string]string{"fields": "id"})
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("Expected non-nil response")
+		}
+	})
+
+	t.Run("POST request", func(t *testing.T) {
+		client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				t.Errorf("Expected POST, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(`{"id":"12345"}`))
+		}))
+
+		resp, err := client.TestAPICall("POST", "/v1.0/me/threads", map[string]string{})
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("Expected non-nil response")
+		}
+	})
+
+	t.Run("default method uses GET", func(t *testing.T) {
+		client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "GET" {
+				t.Errorf("Expected GET for default, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(`{"id":"12345"}`))
+		}))
+
+		resp, err := client.TestAPICall("PATCH", "/v1.0/me", nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("Expected non-nil response")
+		}
+	})
+}
+
+func TestSafeJSONUnmarshal(t *testing.T) {
+	t.Run("empty data", func(t *testing.T) {
+		var result map[string]string
+		err := safeJSONUnmarshal([]byte{}, &result, "test", "req-1")
+		if err == nil {
+			t.Fatal("Expected error for empty data")
+		}
+	})
+
+	t.Run("whitespace only", func(t *testing.T) {
+		var result map[string]string
+		err := safeJSONUnmarshal([]byte("   "), &result, "test", "req-1")
+		if err == nil {
+			t.Fatal("Expected error for whitespace-only data")
+		}
+	})
+
+	t.Run("non-JSON response", func(t *testing.T) {
+		var result map[string]string
+		err := safeJSONUnmarshal([]byte("Not JSON data"), &result, "test", "req-1")
+		if err == nil {
+			t.Fatal("Expected error for non-JSON data")
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		var result map[string]string
+		err := safeJSONUnmarshal([]byte(`{"broken`), &result, "test", "req-1")
+		if err == nil {
+			t.Fatal("Expected error for invalid JSON")
+		}
+	})
+
+	t.Run("valid JSON object", func(t *testing.T) {
+		var result map[string]string
+		err := safeJSONUnmarshal([]byte(`{"key":"value"}`), &result, "test", "req-1")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if result["key"] != "value" {
+			t.Errorf("Expected key=value, got %q", result["key"])
+		}
+	})
+
+	t.Run("valid JSON array", func(t *testing.T) {
+		var result []int
+		err := safeJSONUnmarshal([]byte(`[1,2,3]`), &result, "test", "req-1")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if len(result) != 3 {
+			t.Errorf("Expected 3 elements, got %d", len(result))
+		}
+	})
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("invalid redirect URI format", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "ftp://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for non-HTTP redirect URI")
+		}
+	})
+
+	t.Run("empty scopes", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for empty scopes")
+		}
+	})
+
+	t.Run("invalid scope", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"invalid_scope"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for invalid scope")
+		}
+	})
+
+	t.Run("negative HTTP timeout", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  -1 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for negative HTTPTimeout")
+		}
+	})
+
+	t.Run("retry config negative max retries", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+			RetryConfig: &RetryConfig{
+				MaxRetries:    -1,
+				InitialDelay:  time.Second,
+				MaxDelay:      30 * time.Second,
+				BackoffFactor: 2.0,
+			},
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for negative max retries")
+		}
+	})
+
+	t.Run("retry config zero initial delay", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+			RetryConfig: &RetryConfig{
+				MaxRetries:    3,
+				InitialDelay:  0,
+				MaxDelay:      30 * time.Second,
+				BackoffFactor: 2.0,
+			},
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for zero initial delay")
+		}
+	})
+
+	t.Run("retry config zero max delay", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+			RetryConfig: &RetryConfig{
+				MaxRetries:    3,
+				InitialDelay:  time.Second,
+				MaxDelay:      0,
+				BackoffFactor: 2.0,
+			},
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for zero max delay")
+		}
+	})
+
+	t.Run("retry config zero backoff factor", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+			RetryConfig: &RetryConfig{
+				MaxRetries:    3,
+				InitialDelay:  time.Second,
+				MaxDelay:      30 * time.Second,
+				BackoffFactor: 0,
+			},
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for zero backoff factor")
+		}
+	})
+
+	t.Run("retry config initial delay greater than max delay", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+			RetryConfig: &RetryConfig{
+				MaxRetries:    3,
+				InitialDelay:  time.Minute,
+				MaxDelay:      time.Second,
+				BackoffFactor: 2.0,
+			},
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for InitialDelay > MaxDelay")
+		}
+	})
+
+	t.Run("empty BaseURL", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "",
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for empty BaseURL")
+		}
+	})
+
+	t.Run("invalid BaseURL scheme", func(t *testing.T) {
+		config := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "ftp://graph.threads.net",
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("Expected error for non-HTTP BaseURL")
+		}
+	})
+}
+
+func TestSetTokenInfoNil(t *testing.T) {
+	config := NewConfig()
+	config.ClientID = "test"
+	config.ClientSecret = "secret"
+	config.RedirectURI = "http://localhost"
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.SetTokenInfo(nil)
+	if err == nil {
+		t.Fatal("Expected error for nil tokenInfo")
+	}
+}
+
+func TestGetTokenInfoNilToken(t *testing.T) {
+	config := NewConfig()
+	config.ClientID = "test"
+	config.ClientSecret = "secret"
+	config.RedirectURI = "http://localhost"
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	info := client.GetTokenInfo()
+	if info != nil {
+		t.Error("Expected nil for client with no token")
+	}
+}
+
+func TestMemoryTokenStorageLoad(t *testing.T) {
+	storage := &MemoryTokenStorage{}
+
+	// Load from empty storage
+	_, err := storage.Load()
+	if err == nil {
+		t.Fatal("Expected error for empty storage")
+	}
+
+	// Store and load
+	token := &TokenInfo{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	if err := storage.Store(token); err != nil {
+		t.Fatalf("Store failed: %v", err)
+	}
+
+	loaded, err := storage.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.AccessToken != "test-token" {
+		t.Errorf("Expected 'test-token', got %q", loaded.AccessToken)
 	}
 }
 
@@ -829,4 +1874,214 @@ func TestWaitForContainerReadyRespectsContext(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Expected context.DeadlineExceeded, got: %v", err)
 	}
+}
+
+func TestHandleAPIError(t *testing.T) {
+	client := newBareClient(t)
+
+	tests := []struct {
+		name       string
+		resp       *Response
+		checkError func(t *testing.T, err error)
+	}{
+		{
+			name: "401 auth error",
+			resp: &Response{
+				StatusCode: 401,
+				Body:       []byte(`{"error":{"message":"Invalid token","type":"OAuthException","code":190}}`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsAuthenticationError(err) {
+					t.Errorf("Expected authentication error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "403 auth error",
+			resp: &Response{
+				StatusCode: 403,
+				Body:       []byte(`{"error":{"message":"Permission denied","type":"OAuthException","code":200}}`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsAuthenticationError(err) {
+					t.Errorf("Expected authentication error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "429 rate limit error",
+			resp: &Response{
+				StatusCode: 429,
+				Body:       []byte(`{"error":{"message":"Rate limited","type":"OAuthException","code":32}}`),
+				RateLimit:  &RateLimitInfo{RetryAfter: 60 * time.Second},
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsRateLimitError(err) {
+					t.Errorf("Expected rate limit error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "429 rate limit error without rate limit info",
+			resp: &Response{
+				StatusCode: 429,
+				Body:       []byte(`{"error":{"message":"Rate limited","type":"OAuthException","code":32}}`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsRateLimitError(err) {
+					t.Errorf("Expected rate limit error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "400 validation error",
+			resp: &Response{
+				StatusCode: 400,
+				Body:       []byte(`{"error":{"message":"Invalid param","type":"OAuthException","code":100}}`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsValidationError(err) {
+					t.Errorf("Expected validation error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "422 validation error",
+			resp: &Response{
+				StatusCode: 422,
+				Body:       []byte(`{"error":{"message":"Unprocessable","type":"OAuthException","code":422}}`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsValidationError(err) {
+					t.Errorf("Expected validation error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "500 generic API error",
+			resp: &Response{
+				StatusCode: 500,
+				Body:       []byte(`{"error":{"message":"Server error","type":"ServerException","code":2,"is_transient":true,"error_subcode":1234,"error_data":{"details":"internal"}}}`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsAPIError(err) {
+					t.Errorf("Expected API error, got %T", err)
+				}
+				if !IsTransientError(err) {
+					t.Error("Expected transient error")
+				}
+			},
+		},
+		{
+			name: "error with zero error code uses status code",
+			resp: &Response{
+				StatusCode: 503,
+				Body:       []byte(`{"error":{"message":"Service unavailable","type":"ServerException","code":0}}`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsAPIError(err) {
+					t.Errorf("Expected API error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "empty body fallback",
+			resp: &Response{
+				StatusCode: 502,
+				Body:       []byte{},
+				RequestID:  "req-123",
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsAPIError(err) {
+					t.Errorf("Expected API error, got %T", err)
+				}
+				if !strings.Contains(err.Error(), "502") {
+					t.Errorf("Expected status code in error message, got: %s", err.Error())
+				}
+			},
+		},
+		{
+			name: "malformed JSON fallback",
+			resp: &Response{
+				StatusCode: 500,
+				Body:       []byte(`not json at all`),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsAPIError(err) {
+					t.Errorf("Expected API error, got %T", err)
+				}
+			},
+		},
+		{
+			name: "long body gets truncated in fallback",
+			resp: &Response{
+				StatusCode: 500,
+				Body:       []byte(strings.Repeat("x", 600)),
+			},
+			checkError: func(t *testing.T, err error) {
+				if !IsAPIError(err) {
+					t.Errorf("Expected API error, got %T", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := client.handleAPIError(tt.resp)
+			if err == nil {
+				t.Fatal("Expected error, got nil")
+			}
+			tt.checkError(t, err)
+		})
+	}
+}
+
+func TestEnsureValidToken_RefreshPath(t *testing.T) {
+	// Test: token valid, no refresh needed
+	t.Run("token valid", func(t *testing.T) {
+		client := newBareClient(t)
+		client.accessToken = "test-token"
+		client.tokenInfo = &TokenInfo{
+			ExpiresAt: time.Now().Add(24 * time.Hour),
+			CreatedAt: time.Now(),
+		}
+
+		err := client.EnsureValidToken(context.Background())
+		if err != nil {
+			t.Errorf("Expected no error for valid token, got: %v", err)
+		}
+	})
+
+	// Test: token expired, refresh fails
+	t.Run("expired token refresh fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(400)
+			fmt.Fprintln(w, `{"error":{"message":"refresh failed"}}`)
+		}))
+		defer server.Close()
+
+		config := NewConfig()
+		config.ClientID = "test-id"
+		config.ClientSecret = "test-secret"
+		config.RedirectURI = "https://example.com/callback"
+		config.BaseURL = server.URL
+		client, err := NewClient(config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		client.accessToken = "test-token"
+		client.tokenInfo = &TokenInfo{
+			ExpiresAt: time.Now().Add(-1 * time.Hour), // expired
+			CreatedAt: time.Now().Add(-25 * time.Hour),
+		}
+
+		err = client.EnsureValidToken(context.Background())
+		if err == nil {
+			t.Fatal("Expected error for expired token with failed refresh")
+		}
+		if !strings.Contains(err.Error(), "failed to refresh token") {
+			t.Errorf("Expected 'failed to refresh token' in error, got: %v", err)
+		}
+	})
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,6 +2,8 @@ package threads
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -42,12 +44,9 @@ func TestIsNetworkError(t *testing.T) {
 
 	t.Run("returns true for wrapped NetworkError", func(t *testing.T) {
 		netErr := NewNetworkError(0, "timeout", "details", true)
-		wrapped := errors.New("wrapper: " + netErr.Error())
-		// Need to use fmt.Errorf %w for proper wrapping
-		_ = wrapped
-		// Test with errors.As compatible wrapping
-		if IsNetworkError(errors.New("not a network error")) {
-			t.Error("Expected IsNetworkError to return false for plain error")
+		wrapped := fmt.Errorf("wrapper: %w", netErr)
+		if !IsNetworkError(wrapped) {
+			t.Error("Expected IsNetworkError to return true for wrapped NetworkError")
 		}
 	})
 
@@ -99,7 +98,7 @@ func TestBaseErrorError(t *testing.T) {
 			t.Fatal("Expected non-empty error string")
 		}
 		// Should contain details
-		if !contains(errStr, "field X is invalid") {
+		if !strings.Contains(errStr, "field X is invalid") {
 			t.Errorf("Expected error string to contain details, got: %s", errStr)
 		}
 	})
@@ -115,7 +114,7 @@ func TestBaseErrorError(t *testing.T) {
 			t.Fatal("Expected non-empty error string")
 		}
 		// Should not contain " - " separator since there are no details
-		if contains(errStr, " - ") {
+		if strings.Contains(errStr, " - ") {
 			t.Errorf("Expected error string without details separator, got: %s", errStr)
 		}
 	})
@@ -186,16 +185,3 @@ func TestExtractBaseError(t *testing.T) {
 	})
 }
 
-// helper for string containment checks
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
-}
-
-func containsStr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,201 @@
+package threads
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewNetworkError(t *testing.T) {
+	err := NewNetworkError(0, "connection refused", "details", true)
+	if err == nil {
+		t.Fatal("Expected non-nil error")
+	}
+	if err.Code != 0 {
+		t.Errorf("Expected code 0, got %d", err.Code)
+	}
+	if err.Message != "connection refused" {
+		t.Errorf("Expected message 'connection refused', got %q", err.Message)
+	}
+	if !err.Temporary {
+		t.Error("Expected Temporary to be true")
+	}
+	if err.Cause != nil {
+		t.Error("Expected Cause to be nil for NewNetworkError")
+	}
+}
+
+func TestNewNetworkError_NonTemporary(t *testing.T) {
+	err := NewNetworkError(0, "DNS failure", "could not resolve", false)
+	if err.Temporary {
+		t.Error("Expected Temporary to be false")
+	}
+}
+
+func TestIsNetworkError(t *testing.T) {
+	t.Run("returns true for NetworkError", func(t *testing.T) {
+		err := NewNetworkError(0, "timeout", "details", true)
+		if !IsNetworkError(err) {
+			t.Error("Expected IsNetworkError to return true")
+		}
+	})
+
+	t.Run("returns true for wrapped NetworkError", func(t *testing.T) {
+		netErr := NewNetworkError(0, "timeout", "details", true)
+		wrapped := errors.New("wrapper: " + netErr.Error())
+		// Need to use fmt.Errorf %w for proper wrapping
+		_ = wrapped
+		// Test with errors.As compatible wrapping
+		if IsNetworkError(errors.New("not a network error")) {
+			t.Error("Expected IsNetworkError to return false for plain error")
+		}
+	})
+
+	t.Run("returns false for non-NetworkError", func(t *testing.T) {
+		err := NewAPIError(500, "server error", "details", "req-123")
+		if IsNetworkError(err) {
+			t.Error("Expected IsNetworkError to return false for APIError")
+		}
+	})
+
+	t.Run("returns false for nil", func(t *testing.T) {
+		if IsNetworkError(nil) {
+			t.Error("Expected IsNetworkError to return false for nil")
+		}
+	})
+}
+
+func TestNewRateLimitError(t *testing.T) {
+	retryAfter := 30 * time.Second
+	err := NewRateLimitError(429, "too many requests", "rate limited", retryAfter)
+
+	if err == nil {
+		t.Fatal("Expected non-nil error")
+	}
+	if err.Code != 429 {
+		t.Errorf("Expected code 429, got %d", err.Code)
+	}
+	if err.Message != "too many requests" {
+		t.Errorf("Expected message 'too many requests', got %q", err.Message)
+	}
+	if err.RetryAfter != retryAfter {
+		t.Errorf("Expected RetryAfter %v, got %v", retryAfter, err.RetryAfter)
+	}
+	if err.Type != "rate_limit_error" {
+		t.Errorf("Expected type 'rate_limit_error', got %q", err.Type)
+	}
+}
+
+func TestBaseErrorError(t *testing.T) {
+	t.Run("with details", func(t *testing.T) {
+		err := &BaseError{
+			Code:    400,
+			Message: "Bad request",
+			Type:    "validation_error",
+			Details: "field X is invalid",
+		}
+		errStr := err.Error()
+		if errStr == "" {
+			t.Fatal("Expected non-empty error string")
+		}
+		// Should contain details
+		if !contains(errStr, "field X is invalid") {
+			t.Errorf("Expected error string to contain details, got: %s", errStr)
+		}
+	})
+
+	t.Run("without details", func(t *testing.T) {
+		err := &BaseError{
+			Code:    400,
+			Message: "Bad request",
+			Type:    "validation_error",
+		}
+		errStr := err.Error()
+		if errStr == "" {
+			t.Fatal("Expected non-empty error string")
+		}
+		// Should not contain " - " separator since there are no details
+		if contains(errStr, " - ") {
+			t.Errorf("Expected error string without details separator, got: %s", errStr)
+		}
+	})
+}
+
+func TestExtractBaseError(t *testing.T) {
+	t.Run("AuthenticationError", func(t *testing.T) {
+		err := NewAuthenticationError(401, "unauthorized", "details")
+		base := extractBaseError(err)
+		if base == nil {
+			t.Fatal("Expected non-nil BaseError")
+		}
+		if base.Code != 401 {
+			t.Errorf("Expected code 401, got %d", base.Code)
+		}
+	})
+
+	t.Run("RateLimitError", func(t *testing.T) {
+		err := NewRateLimitError(429, "rate limited", "details", time.Minute)
+		base := extractBaseError(err)
+		if base == nil {
+			t.Fatal("Expected non-nil BaseError")
+		}
+		if base.Code != 429 {
+			t.Errorf("Expected code 429, got %d", base.Code)
+		}
+	})
+
+	t.Run("ValidationError", func(t *testing.T) {
+		err := NewValidationError(400, "invalid", "details", "field")
+		base := extractBaseError(err)
+		if base == nil {
+			t.Fatal("Expected non-nil BaseError")
+		}
+		if base.Code != 400 {
+			t.Errorf("Expected code 400, got %d", base.Code)
+		}
+	})
+
+	t.Run("NetworkError", func(t *testing.T) {
+		err := NewNetworkError(0, "timeout", "details", true)
+		base := extractBaseError(err)
+		if base == nil {
+			t.Fatal("Expected non-nil BaseError")
+		}
+		if base.Type != "network_error" {
+			t.Errorf("Expected type 'network_error', got %q", base.Type)
+		}
+	})
+
+	t.Run("APIError", func(t *testing.T) {
+		err := NewAPIError(500, "server error", "details", "req-123")
+		base := extractBaseError(err)
+		if base == nil {
+			t.Fatal("Expected non-nil BaseError")
+		}
+		if base.Code != 500 {
+			t.Errorf("Expected code 500, got %d", base.Code)
+		}
+	})
+
+	t.Run("unknown error type returns nil", func(t *testing.T) {
+		err := errors.New("plain error")
+		base := extractBaseError(err)
+		if base != nil {
+			t.Errorf("Expected nil for unknown error type, got %v", base)
+		}
+	})
+}
+
+// helper for string containment checks
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -184,4 +184,3 @@ func TestExtractBaseError(t *testing.T) {
 		}
 	})
 }
-

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -2,7 +2,10 @@ package threads
 
 import (
 	"context"
+	"errors"
+	"net"
 	"net/http"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -118,5 +121,352 @@ func TestHTTPClient_ParseRateLimitHeaders(t *testing.T) {
 	}
 	if resp.RateLimit.Remaining != 42 {
 		t.Errorf("expected remaining 42, got %d", resp.RateLimit.Remaining)
+	}
+}
+
+func TestHTTPClient_PUT(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	resp, err := httpClient.PUT("/test", url.Values{"key": {"value"}}, "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPClient_DELETE(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	resp, err := httpClient.DELETE("/test", "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPClient_POST_URLValues(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			t.Errorf("expected application/x-www-form-urlencoded, got %s", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	_, err := httpClient.POST("/test", url.Values{"key": {"val"}}, "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPClient_POST_JSONBody(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	// Passing a struct should be JSON-encoded
+	_, err := httpClient.POST("/test", map[string]string{"key": "value"}, "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPClient_POST_StringBody(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "text/plain" {
+			t.Errorf("expected text/plain, got %s", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	_, err := httpClient.POST("/test", "hello body", "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPClient_POST_ByteBody(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/octet-stream" {
+			t.Errorf("expected application/octet-stream, got %s", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	_, err := httpClient.POST("/test", []byte("binary data"), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWrapNetworkError_Timeout(t *testing.T) {
+	httpClient := &HTTPClient{
+		logger: &noopLogger{},
+	}
+	// Create a timeout error
+	timeoutErr := &net.DNSError{IsTimeout: true}
+	wrapped := httpClient.wrapNetworkError(timeoutErr)
+	var netErr *NetworkError
+	if !errors.As(wrapped, &netErr) {
+		t.Fatalf("expected NetworkError, got %T", wrapped)
+	}
+	if !netErr.Temporary {
+		t.Error("expected temporary error for timeout")
+	}
+}
+
+func TestWrapNetworkError_Generic(t *testing.T) {
+	httpClient := &HTTPClient{
+		logger: &noopLogger{},
+	}
+	wrapped := httpClient.wrapNetworkError(errors.New("some network problem"))
+	var netErr *NetworkError
+	if !errors.As(wrapped, &netErr) {
+		t.Fatalf("expected NetworkError, got %T", wrapped)
+	}
+	if netErr.Temporary {
+		t.Error("expected non-temporary error for generic error")
+	}
+}
+
+func TestCreateErrorFromResponse_401(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	resp := &Response{
+		StatusCode: 401,
+		Body:       []byte(`{"error":{"message":"Unauthorized","type":"OAuthException","code":190}}`),
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestCreateErrorFromResponse_429(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	resp := &Response{
+		StatusCode: 429,
+		Body:       []byte(`{"error":{"message":"rate limited","type":"rate_limit","code":429}}`),
+		RateLimit:  &RateLimitInfo{RetryAfter: 60 * time.Second, Reset: time.Now().Add(time.Minute)},
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if !IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got %T", err)
+	}
+}
+
+func TestCreateErrorFromResponse_429_NoRateLimit(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	resp := &Response{
+		StatusCode: 429,
+		Body:       []byte(`{"error":{"message":"rate limited"}}`),
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if !IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got %T", err)
+	}
+}
+
+func TestCreateErrorFromResponse_429_WithRateLimiter(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	httpClient := &HTTPClient{logger: &noopLogger{}, rateLimiter: rl}
+	resp := &Response{
+		StatusCode: 429,
+		Body:       []byte(`{"error":{"message":"rate limited"}}`),
+		RateLimit:  &RateLimitInfo{RetryAfter: 30 * time.Second},
+	}
+	_ = httpClient.createErrorFromResponse(resp)
+	if !rl.IsRateLimited() {
+		t.Error("expected rate limiter to be marked as rate limited")
+	}
+}
+
+func TestCreateErrorFromResponse_400(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	resp := &Response{
+		StatusCode: 400,
+		Body:       []byte(`{"error":{"message":"Bad request","type":"validation","code":100}}`),
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateErrorFromResponse_422(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	resp := &Response{
+		StatusCode: 422,
+		Body:       []byte(`{"error":{"message":"Unprocessable","type":"validation","code":100}}`),
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateErrorFromResponse_500(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	resp := &Response{
+		StatusCode: 500,
+		Body:       []byte(`{"error":{"message":"Server error","type":"server","code":500,"is_transient":true}}`),
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if !IsAPIError(err) {
+		t.Errorf("expected APIError, got %T", err)
+	}
+}
+
+func TestCreateErrorFromResponse_EmptyBody(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	resp := &Response{
+		StatusCode: 500,
+		Body:       nil,
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateErrorFromResponse_LongBody(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	// Create a body longer than 500 chars
+	longBody := make([]byte, 600)
+	for i := range longBody {
+		longBody[i] = 'x'
+	}
+	resp := &Response{
+		StatusCode: 500,
+		Body:       longBody,
+	}
+	err := httpClient.createErrorFromResponse(resp)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLogRequest_WithLogger(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	// Should not panic
+	httpClient.logRequest(req, nil)
+}
+
+func TestLogRequest_WithJSONBody(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	req, _ := http.NewRequest("POST", "http://example.com/test", nil)
+	req.Header.Set("Content-Type", "application/json")
+	httpClient.logRequest(req, map[string]string{"key": "value"})
+}
+
+func TestLogRequest_WithNonJSONBody(t *testing.T) {
+	httpClient := &HTTPClient{logger: &noopLogger{}}
+	req, _ := http.NewRequest("POST", "http://example.com/test", nil)
+	req.Header.Set("Content-Type", "text/plain")
+	httpClient.logRequest(req, "hello")
+}
+
+func TestLogRequest_NilLogger(t *testing.T) {
+	httpClient := &HTTPClient{logger: nil}
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	// Should not panic
+	httpClient.logRequest(req, nil)
+}
+
+func TestHTTPClient_ParseRetryAfterHeader(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("Retry-After", "60")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	resp, err := httpClient.Do(&RequestOptions{Method: "GET", Path: "/test"}, "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.RateLimit.RetryAfter != 60*time.Second {
+		t.Errorf("expected 60s retry after, got %v", resp.RateLimit.RetryAfter)
+	}
+}
+
+func TestHTTPClient_NoRateLimitHeaders(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	httpClient := newTestHTTPClient(t, http.HandlerFunc(handler), &RetryConfig{
+		MaxRetries: 0, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 1.0,
+	})
+
+	resp, err := httpClient.Do(&RequestOptions{Method: "GET", Path: "/test"}, "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.RateLimit != nil {
+		t.Error("expected nil rate limit info when no headers")
 	}
 }

--- a/insights_test.go
+++ b/insights_test.go
@@ -3,6 +3,7 @@ package threads
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestGetPostInsights_Success(t *testing.T) {
@@ -33,6 +34,89 @@ func TestGetPostInsights_InvalidPostID(t *testing.T) {
 	}
 }
 
+func TestGetPostInsights_InvalidMetric(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPostInsights(context.Background(), ConvertToPostID("post_1"), []string{"invalid_metric"})
+	if err == nil {
+		t.Fatal("expected error for invalid metric")
+	}
+}
+
+func TestGetPostInsights_DefaultMetrics(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+	_, err := client.GetPostInsights(context.Background(), ConvertToPostID("post_1"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetPostInsightsWithOptions_Success(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[{"name":"views","period":"day","values":[{"value":50}]}]}`))
+	since := time.Now().Add(-24 * time.Hour)
+	until := time.Now()
+	resp, err := client.GetPostInsightsWithOptions(context.Background(), ConvertToPostID("post_1"), &PostInsightsOptions{
+		Metrics: []PostInsightMetric{PostInsightViews},
+		Period:  InsightPeriodDay,
+		Since:   &since,
+		Until:   &until,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Errorf("expected 1 metric, got %d", len(resp.Data))
+	}
+}
+
+func TestGetPostInsightsWithOptions_InvalidPostID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPostInsightsWithOptions(context.Background(), PostID(""), nil)
+	if err == nil {
+		t.Fatal("expected error for empty post ID")
+	}
+}
+
+func TestGetPostInsightsWithOptions_NilOpts(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+	_, err := client.GetPostInsightsWithOptions(context.Background(), ConvertToPostID("post_1"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetPostInsightsWithOptions_InvalidMetric(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPostInsightsWithOptions(context.Background(), ConvertToPostID("post_1"), &PostInsightsOptions{
+		Metrics: []PostInsightMetric{"invalid"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid metric")
+	}
+}
+
+func TestGetPostInsightsWithOptions_InvalidPeriod(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPostInsightsWithOptions(context.Background(), ConvertToPostID("post_1"), &PostInsightsOptions{
+		Period: "weekly",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid period")
+	}
+}
+
+func TestGetPostInsightsWithOptions_InvalidDateRange(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	since := time.Now()
+	until := time.Now().Add(-24 * time.Hour) // until before since
+	_, err := client.GetPostInsightsWithOptions(context.Background(), ConvertToPostID("post_1"), &PostInsightsOptions{
+		Since: &since,
+		Until: &until,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid date range")
+	}
+}
+
 func TestGetAccountInsights_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{
 		"data": [{"name": "followers_count", "period": "day", "values": [{"value": 500}]}]
@@ -44,5 +128,225 @@ func TestGetAccountInsights_Success(t *testing.T) {
 	}
 	if len(resp.Data) != 1 {
 		t.Errorf("expected 1 metric, got %d", len(resp.Data))
+	}
+}
+
+func TestGetAccountInsights_InvalidUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetAccountInsights(context.Background(), UserID(""), nil, "")
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestGetAccountInsights_DefaultMetrics(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+	_, err := client.GetAccountInsights(context.Background(), ConvertToUserID("12345"), nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAccountInsights_InvalidMetric(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetAccountInsights(context.Background(), ConvertToUserID("12345"), []string{"bad_metric"}, "day")
+	if err == nil {
+		t.Fatal("expected error for invalid metric")
+	}
+}
+
+func TestGetAccountInsights_InvalidPeriod(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetAccountInsights(context.Background(), ConvertToUserID("12345"), []string{"views"}, "weekly")
+	if err == nil {
+		t.Fatal("expected error for invalid period")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_Success(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[{"name":"views","period":"day","values":[{"value":100}]}]}`))
+	since := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+	resp, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics: []AccountInsightMetric{AccountInsightViews},
+		Period:  InsightPeriodDay,
+		Since:   &since,
+		Until:   &until,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Errorf("expected 1 metric, got %d", len(resp.Data))
+	}
+}
+
+func TestGetAccountInsightsWithOptions_InvalidUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), UserID(""), nil)
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_NilOpts(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAccountInsightsWithOptions_InvalidMetric(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics: []AccountInsightMetric{"invalid"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid metric")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_InvalidPeriod(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Period: "weekly",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid period")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_FollowerDemographicsWithSince(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	since := time.Now()
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics: []AccountInsightMetric{AccountInsightFollowerDemographics},
+		Since:   &since,
+	})
+	if err == nil {
+		t.Fatal("expected error for follower_demographics with since")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_FollowerDemographicsWithBreakdown(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics:   []AccountInsightMetric{AccountInsightFollowerDemographics},
+		Breakdown: "country",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAccountInsightsWithOptions_FollowerDemographicsInvalidBreakdown(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics:   []AccountInsightMetric{AccountInsightFollowerDemographics},
+		Breakdown: "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid breakdown")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_FollowersCountWithSince(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	since := time.Now()
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics: []AccountInsightMetric{AccountInsightFollowersCount},
+		Since:   &since,
+	})
+	if err == nil {
+		t.Fatal("expected error for followers_count with since")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_MinSinceTimestamp(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	// Timestamp before MinInsightTimestamp
+	early := time.Unix(100, 0)
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics: []AccountInsightMetric{AccountInsightViews},
+		Since:   &early,
+	})
+	if err == nil {
+		t.Fatal("expected error for since before MinInsightTimestamp")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_MinUntilTimestamp(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	early := time.Unix(100, 0)
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics: []AccountInsightMetric{AccountInsightViews},
+		Until:   &early,
+	})
+	if err == nil {
+		t.Fatal("expected error for until before MinInsightTimestamp")
+	}
+}
+
+func TestGetAccountInsightsWithOptions_InvalidDateRange(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	since := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	_, err := client.GetAccountInsightsWithOptions(context.Background(), ConvertToUserID("12345"), &AccountInsightsOptions{
+		Metrics: []AccountInsightMetric{AccountInsightViews},
+		Since:   &since,
+		Until:   &until,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid date range")
+	}
+}
+
+func TestValidateFollowerDemographicsBreakdown_ValidValues(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	for _, b := range []string{"country", "city", "age", "gender"} {
+		if err := client.validateFollowerDemographicsBreakdown(b); err != nil {
+			t.Errorf("expected no error for breakdown %s, got %v", b, err)
+		}
+	}
+}
+
+func TestValidateFollowerDemographicsBreakdown_Invalid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.validateFollowerDemographicsBreakdown("invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid breakdown")
+	}
+}
+
+func TestGetAvailablePostInsightMetrics(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	metrics := client.GetAvailablePostInsightMetrics()
+	if len(metrics) != 6 {
+		t.Errorf("expected 6 metrics, got %d", len(metrics))
+	}
+}
+
+func TestGetAvailableAccountInsightMetrics(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	metrics := client.GetAvailableAccountInsightMetrics()
+	if len(metrics) != 8 {
+		t.Errorf("expected 8 metrics, got %d", len(metrics))
+	}
+}
+
+func TestGetAvailableInsightPeriods(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	periods := client.GetAvailableInsightPeriods()
+	if len(periods) != 2 {
+		t.Errorf("expected 2 periods, got %d", len(periods))
+	}
+}
+
+func TestGetAvailableFollowerDemographicsBreakdowns(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	breakdowns := client.GetAvailableFollowerDemographicsBreakdowns()
+	if len(breakdowns) != 4 {
+		t.Errorf("expected 4 breakdowns, got %d", len(breakdowns))
 	}
 }

--- a/location_test.go
+++ b/location_test.go
@@ -2,6 +2,7 @@ package threads
 
 import (
 	"context"
+	"net/http"
 	"testing"
 )
 
@@ -30,6 +31,57 @@ func TestSearchLocations_EmptyQuery(t *testing.T) {
 	}
 }
 
+func TestSearchLocations_WithLatLong(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("latitude") == "" {
+			t.Error("expected latitude parameter")
+		}
+		if q.Get("longitude") == "" {
+			t.Error("expected longitude parameter")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	lat := 37.7749
+	lng := -122.4194
+	_, err := client.SearchLocations(context.Background(), "", &lat, &lng)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchLocations_WithQueryAndLatLong(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("q") != "cafe" {
+			t.Errorf("expected q=cafe, got %s", q.Get("q"))
+		}
+		if q.Get("latitude") == "" {
+			t.Error("expected latitude parameter")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"id":"1","name":"Cafe"}]}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	lat := 37.7749
+	_, err := client.SearchLocations(context.Background(), "cafe", &lat, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchLocations_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.SearchLocations(context.Background(), "cafe", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
 func TestGetLocation_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{
 		"id": "loc1",
@@ -53,5 +105,94 @@ func TestGetLocation_InvalidID(t *testing.T) {
 	_, err := client.GetLocation(context.Background(), LocationID(""))
 	if err == nil {
 		t.Fatal("expected error for empty location ID")
+	}
+}
+
+func TestGetLocation_404(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found"}}`))
+	_, err := client.GetLocation(context.Background(), ConvertToLocationID("nonexistent"))
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetLocation_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.GetLocation(context.Background(), ConvertToLocationID("loc1"))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestGetLocation_FullDetails(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{
+		"id": "loc1",
+		"name": "Cafe Central",
+		"address": "123 Main St",
+		"city": "New York",
+		"country": "US",
+		"latitude": 40.7128,
+		"longitude": -74.0060,
+		"postal_code": "10001"
+	}`))
+	loc, err := client.GetLocation(context.Background(), ConvertToLocationID("loc1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loc.Address != "123 Main St" {
+		t.Errorf("expected 123 Main St, got %s", loc.Address)
+	}
+	if loc.Country != "US" {
+		t.Errorf("expected US, got %s", loc.Country)
+	}
+}
+
+func TestSearchLocations_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.SearchLocations(context.Background(), "coffee", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestSearchLocations_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+	_, err := client.SearchLocations(context.Background(), "coffee", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestGetLocation_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetLocation(context.Background(), ConvertToLocationID("loc1"))
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestGetLocation_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+	_, err := client.GetLocation(context.Background(), ConvertToLocationID("loc1"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestSearchLocations_OnlyLatitude(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+	lat := 37.7749
+	_, err := client.SearchLocations(context.Background(), "", &lat, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchLocations_OnlyLongitude(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+	lng := -122.4194
+	_, err := client.SearchLocations(context.Background(), "", nil, &lng)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -64,9 +64,163 @@ func TestPostIterator_Reset(t *testing.T) {
 	}
 }
 
+func TestPostIterator_PagingAfterFallback(t *testing.T) {
+	// Test using Paging.After (deprecated field) instead of Paging.Cursors.After
+	var callCount int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if count == 1 {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1"}],"paging":{"after":"page2_cursor"}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	iter := NewPostIterator(client, ConvertToUserID("12345"), nil)
+	posts, err := iter.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(posts) != 1 {
+		t.Errorf("expected 1 post, got %d", len(posts))
+	}
+}
+
+func TestPostIterator_NextWhenDone(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[],"paging":{}}`))
+	iter := NewPostIterator(client, ConvertToUserID("12345"), nil)
+	_, _ = iter.Collect(context.Background())
+	resp, err := iter.Next(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Error("expected nil response when done")
+	}
+}
+
+// ReplyIterator tests
+
+func TestReplyIterator_Success(t *testing.T) {
+	var callCount int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if count == 1 {
+			_, _ = w.Write([]byte(`{"data":[{"id":"r1"},{"id":"r2"}],"paging":{"cursors":{"after":"cursor2"}}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"data":[{"id":"r3"}],"paging":{}}`))
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	iter := NewReplyIterator(client, ConvertToPostID("post_1"), &RepliesOptions{Limit: 2})
+	replies, err := iter.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(replies) != 3 {
+		t.Errorf("expected 3 replies, got %d", len(replies))
+	}
+}
+
+func TestReplyIterator_NilOpts(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[{"id":"r1"}],"paging":{}}`))
+	iter := NewReplyIterator(client, ConvertToPostID("post_1"), nil)
+	if !iter.HasNext() {
+		t.Error("expected HasNext to be true")
+	}
+	replies, err := iter.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(replies) != 1 {
+		t.Errorf("expected 1 reply, got %d", len(replies))
+	}
+}
+
+func TestReplyIterator_NextWhenDone(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[],"paging":{}}`))
+	iter := NewReplyIterator(client, ConvertToPostID("post_1"), nil)
+	_, _ = iter.Collect(context.Background())
+	if iter.HasNext() {
+		t.Error("expected HasNext to be false")
+	}
+	resp, err := iter.Next(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Error("expected nil response when done")
+	}
+}
+
+func TestReplyIterator_Reset(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[{"id":"r1"}],"paging":{}}`))
+	iter := NewReplyIterator(client, ConvertToPostID("post_1"), nil)
+	_, _ = iter.Collect(context.Background())
+	if iter.HasNext() {
+		t.Error("expected done after collect")
+	}
+	iter.Reset()
+	if !iter.HasNext() {
+		t.Error("expected HasNext after reset")
+	}
+}
+
+func TestReplyIterator_PagingAfterFallback(t *testing.T) {
+	var callCount int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if count == 1 {
+			_, _ = w.Write([]byte(`{"data":[{"id":"r1"}],"paging":{"after":"next"}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+		}
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	iter := NewReplyIterator(client, ConvertToPostID("post_1"), nil)
+	replies, err := iter.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(replies) != 1 {
+		t.Errorf("expected 1 reply, got %d", len(replies))
+	}
+}
+
+func TestReplyIterator_Error(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error","is_transient":true}}`))
+	iter := NewReplyIterator(client, ConvertToPostID("post_1"), nil)
+	_, err := iter.Collect(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// SearchIterator tests
+
 func TestSearchIterator_Keyword(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{"data":[{"id":"1","text":"match"}],"paging":{}}`))
 	iter := NewSearchIterator(client, "test", "keyword", nil)
+	posts, err := iter.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(posts) != 1 {
+		t.Errorf("expected 1 result, got %d", len(posts))
+	}
+}
+
+func TestSearchIterator_Tag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[{"id":"1","text":"tagged"}],"paging":{}}`))
+	iter := NewSearchIterator(client, "golang", "tag", nil)
 	posts, err := iter.Collect(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -82,5 +236,86 @@ func TestSearchIterator_InvalidType(t *testing.T) {
 	_, err := iter.Next(context.Background())
 	if err == nil {
 		t.Fatal("expected error for invalid search type")
+	}
+}
+
+func TestSearchIterator_Reset(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[{"id":"1"}],"paging":{}}`))
+	iter := NewSearchIterator(client, "test", "keyword", nil)
+	_, _ = iter.Collect(context.Background())
+	if iter.HasNext() {
+		t.Error("expected done after collect")
+	}
+	iter.Reset()
+	if !iter.HasNext() {
+		t.Error("expected HasNext after reset")
+	}
+}
+
+func TestSearchIterator_MultiplePages(t *testing.T) {
+	var callCount int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if count == 1 {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1"}],"paging":{"cursors":{"after":"page2"}}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+		}
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	iter := NewSearchIterator(client, "test", "keyword", nil)
+	posts, err := iter.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(posts) != 1 {
+		t.Errorf("expected 1 post, got %d", len(posts))
+	}
+}
+
+func TestSearchIterator_PagingAfterFallback(t *testing.T) {
+	var callCount int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if count == 1 {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1"}],"paging":{"after":"next"}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+		}
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	iter := NewSearchIterator(client, "test", "keyword", nil)
+	posts, err := iter.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(posts) != 1 {
+		t.Errorf("expected 1 post, got %d", len(posts))
+	}
+}
+
+func TestSearchIterator_NextWhenDone(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[],"paging":{}}`))
+	iter := NewSearchIterator(client, "test", "keyword", nil)
+	_, _ = iter.Collect(context.Background())
+	resp, err := iter.Next(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Error("expected nil response when done")
+	}
+}
+
+func TestSearchIterator_Error(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error","is_transient":true}}`))
+	iter := NewSearchIterator(client, "test", "keyword", nil)
+	_, err := iter.Collect(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }

--- a/posts_create_test.go
+++ b/posts_create_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestCreateTextPost_Success(t *testing.T) {
@@ -252,5 +253,932 @@ func TestGetContainerStatus_InvalidID(t *testing.T) {
 	_, err := client.GetContainerStatus(context.Background(), ContainerID(""))
 	if err == nil {
 		t.Fatal("expected error for empty container ID")
+	}
+}
+
+func TestGetContainerStatus_APIError(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"Server error","type":"OAuthException","code":2}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetContainerStatus(context.Background(), ConvertToContainerID("container_1"))
+	if err == nil {
+		t.Fatal("expected error for API error")
+	}
+}
+
+func TestGetContainerStatus_MissingStatus(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":"container_1"}`))
+
+	_, err := client.GetContainerStatus(context.Background(), ConvertToContainerID("container_1"))
+	if err == nil {
+		t.Fatal("expected error for missing status")
+	}
+}
+
+func TestGetContainerStatus_MissingID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"status":"FINISHED"}`))
+
+	_, err := client.GetContainerStatus(context.Background(), ConvertToContainerID("container_1"))
+	if err == nil {
+		t.Fatal("expected error for missing ID in response")
+	}
+}
+
+func TestCreateCarouselPost_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_1"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_1","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_2"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_2","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/carousel_container"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_container","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/carousel_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_post","media_type":"CAROUSEL"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	post, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "My carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "carousel_post" {
+		t.Errorf("expected carousel_post, got %s", post.ID)
+	}
+}
+
+func TestCreateCarouselPost_EmptyChildren(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Children: []string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty children")
+	}
+}
+
+func TestCreateCarouselPost_NilContent(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateCarouselPost(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil content")
+	}
+}
+
+func TestCreateCarouselPost_ChildNotReady(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_1"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_1","status":"ERROR","error_message":"processing failed"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_2"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_2","status":"FINISHED"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "Carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err == nil {
+		t.Fatal("expected error when child container fails")
+	}
+	if !strings.Contains(err.Error(), "child container") {
+		t.Errorf("expected child container error, got: %v", err)
+	}
+}
+
+func TestCreateCarouselPost_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "Carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestCreateCarouselPost_ContainerCreateError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_1"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_1","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_2"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_2","status":"FINISHED"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "Carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err == nil {
+		t.Fatal("expected error when container creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create carousel container") {
+		t.Errorf("expected carousel container error, got: %v", err)
+	}
+}
+
+func TestCreateQuotePost_TextQuote(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"quote_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("failed to parse form: %v", err)
+			}
+			if r.PostForm.Get("quote_post_id") != "original_123" {
+				t.Errorf("expected quote_post_id=original_123, got %s", r.PostForm.Get("quote_post_id"))
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"quote_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/quote_container"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"quote_container","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/quote_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"quote_post","text":"Quote this","is_quote_post":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	post, err := client.CreateQuotePost(context.Background(), &TextPostContent{
+		Text: "Quote this",
+	}, "original_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "quote_post" {
+		t.Errorf("expected quote_post, got %s", post.ID)
+	}
+}
+
+func TestCreateQuotePost_ImageQuote(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"img_quote_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"img_quote_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/img_quote_container"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"img_quote_container","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/img_quote_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"img_quote_post","media_type":"IMAGE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	post, err := client.CreateQuotePost(context.Background(), &ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+	}, "original_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "img_quote_post" {
+		t.Errorf("expected img_quote_post, got %s", post.ID)
+	}
+}
+
+func TestCreateQuotePost_VideoQuote(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"vid_quote_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"vid_quote_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/vid_quote_container"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"vid_quote_container","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/vid_quote_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"vid_quote_post","media_type":"VIDEO"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	post, err := client.CreateQuotePost(context.Background(), &VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+	}, "original_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "vid_quote_post" {
+		t.Errorf("expected vid_quote_post, got %s", post.ID)
+	}
+}
+
+func TestCreateQuotePost_CarouselQuote(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_quote_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_quote_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_1"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_1","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_2"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_2","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/carousel_quote_container"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_quote_container","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/carousel_quote_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"carousel_quote_post","media_type":"CAROUSEL"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	post, err := client.CreateQuotePost(context.Background(), &CarouselPostContent{
+		Children: []string{"child_1", "child_2"},
+	}, "original_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "carousel_quote_post" {
+		t.Errorf("expected carousel_quote_post, got %s", post.ID)
+	}
+}
+
+func TestCreateQuotePost_EmptyQuotedID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateQuotePost(context.Background(), &TextPostContent{Text: "Hello"}, "")
+	if err == nil {
+		t.Fatal("expected error for empty quoted post ID")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateQuotePost_UnsupportedContentType(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateQuotePost(context.Background(), "not a valid content type", "original_123")
+	if err == nil {
+		t.Fatal("expected error for unsupported content type")
+	}
+	if !strings.Contains(err.Error(), "unsupported content type") {
+		t.Errorf("expected unsupported content type error, got: %v", err)
+	}
+}
+
+func TestCreateMediaContainer_ImageSuccess(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads") {
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("failed to parse form: %v", err)
+			}
+			if r.PostForm.Get("is_carousel_item") != "true" {
+				t.Error("expected is_carousel_item=true")
+			}
+			if r.PostForm.Get("media_type") != "IMAGE" {
+				t.Errorf("expected media_type=IMAGE, got %s", r.PostForm.Get("media_type"))
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"media_container_1"}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	containerID, err := client.CreateMediaContainer(context.Background(), "IMAGE", "https://example.com/img.jpg", "alt text")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(containerID) != "media_container_1" {
+		t.Errorf("expected media_container_1, got %s", containerID)
+	}
+}
+
+func TestCreateMediaContainer_VideoSuccess(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads") {
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("failed to parse form: %v", err)
+			}
+			if r.PostForm.Get("media_type") != "VIDEO" {
+				t.Errorf("expected media_type=VIDEO, got %s", r.PostForm.Get("media_type"))
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"video_container_1"}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	containerID, err := client.CreateMediaContainer(context.Background(), "video", "https://example.com/vid.mp4", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(containerID) != "video_container_1" {
+		t.Errorf("expected video_container_1, got %s", containerID)
+	}
+}
+
+func TestCreateMediaContainer_EmptyMediaType(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateMediaContainer(context.Background(), "", "https://example.com/img.jpg", "")
+	if err == nil {
+		t.Fatal("expected error for empty media type")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateMediaContainer_EmptyMediaURL(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateMediaContainer(context.Background(), "IMAGE", "", "")
+	if err == nil {
+		t.Fatal("expected error for empty media URL")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateMediaContainer_InvalidMediaType(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateMediaContainer(context.Background(), "AUDIO", "https://example.com/audio.mp3", "")
+	if err == nil {
+		t.Fatal("expected error for invalid media type")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateMediaContainer_InvalidURL(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateMediaContainer(context.Background(), "IMAGE", "not-a-url", "")
+	if err == nil {
+		t.Fatal("expected error for invalid media URL format")
+	}
+}
+
+func TestCreateMediaContainer_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.CreateMediaContainer(context.Background(), "IMAGE", "https://example.com/img.jpg", "")
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestWaitForContainerReady_Finished(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":"c1","status":"FINISHED"}`))
+
+	err := client.waitForContainerReady(context.Background(), ConvertToContainerID("c1"), 3, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitForContainerReady_Error(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":"c1","status":"ERROR","error_message":"upload failed"}`))
+
+	err := client.waitForContainerReady(context.Background(), ConvertToContainerID("c1"), 3, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for container error status")
+	}
+	if !strings.Contains(err.Error(), "upload failed") {
+		t.Errorf("expected error message about upload failure, got: %v", err)
+	}
+}
+
+func TestWaitForContainerReady_ErrorNoMessage(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":"c1","status":"ERROR"}`))
+
+	err := client.waitForContainerReady(context.Background(), ConvertToContainerID("c1"), 3, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for container error status")
+	}
+	if !strings.Contains(err.Error(), "container processing failed with error status") {
+		t.Errorf("expected generic error message, got: %v", err)
+	}
+}
+
+func TestWaitForContainerReady_Expired(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":"c1","status":"EXPIRED"}`))
+
+	err := client.waitForContainerReady(context.Background(), ConvertToContainerID("c1"), 3, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for expired container")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected expired error, got: %v", err)
+	}
+}
+
+func TestWaitForContainerReady_Timeout(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":"c1","status":"IN_PROGRESS"}`))
+
+	err := client.waitForContainerReady(context.Background(), ConvertToContainerID("c1"), 2, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+}
+
+func TestWaitForContainerReady_ContextCancelled(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":"c1","status":"IN_PROGRESS"}`))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := client.waitForContainerReady(ctx, ConvertToContainerID("c1"), 10, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestWaitForContainerReady_ProgressThenFinished(t *testing.T) {
+	var callCount int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if count <= 2 {
+			_, _ = w.Write([]byte(`{"id":"c1","status":"IN_PROGRESS"}`))
+		} else {
+			_, _ = w.Write([]byte(`{"id":"c1","status":"FINISHED"}`))
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	err := client.waitForContainerReady(context.Background(), ConvertToContainerID("c1"), 5, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateImagePost_ContainerCreateError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" {
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+	})
+	if err == nil {
+		t.Fatal("expected error when container creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create image container") {
+		t.Errorf("expected image container error, got: %v", err)
+	}
+}
+
+func TestCreateImagePost_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+	})
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestCreateVideoPost_ContainerCreateError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" {
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateVideoPost(context.Background(), &VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+	})
+	if err == nil {
+		t.Fatal("expected error when container creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create video container") {
+		t.Errorf("expected video container error, got: %v", err)
+	}
+}
+
+func TestCreateVideoPost_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.CreateVideoPost(context.Background(), &VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+	})
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestRepostPost_APIError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.RepostPost(context.Background(), ConvertToPostID("original_post"))
+	if err == nil {
+		t.Fatal("expected error for API error")
+	}
+}
+
+func TestRepostPost_InvalidResponse(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":""}`))
+
+	_, err := client.RepostPost(context.Background(), ConvertToPostID("original_post"))
+	if err == nil {
+		t.Fatal("expected error for empty repost ID in response")
+	}
+}
+
+func TestRepostPost_MalformedResponse(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+
+	_, err := client.RepostPost(context.Background(), ConvertToPostID("original_post"))
+	if err == nil {
+		t.Fatal("expected error for malformed response")
+	}
+}
+
+func TestRepostPost_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.RepostPost(context.Background(), ConvertToPostID("original_post"))
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestCreateTextPost_ContainerCreateError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" {
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text: "Hello",
+	})
+	if err == nil {
+		t.Fatal("expected error when container creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create text container") {
+		t.Errorf("expected text container error, got: %v", err)
+	}
+}
+
+func TestCreateTextPost_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text: "Hello",
+	})
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestCreateTextPost_PublishError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"publish failed","type":"OAuthException","code":100}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"container_1"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/container_1"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"container_1","status":"FINISHED"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text: "Hello",
+	})
+	if err == nil {
+		t.Fatal("expected error when publish fails")
+	}
+	if !strings.Contains(err.Error(), "failed to publish text post") {
+		t.Errorf("expected publish error, got: %v", err)
+	}
+}
+
+func TestCreateTextPost_WaitForContainerError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"container_1"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/container_1"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"container_1","status":"ERROR","error_message":"failed"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	_, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text: "Hello",
+	})
+	if err == nil {
+		t.Fatal("expected error when container not ready")
+	}
+	if !strings.Contains(err.Error(), "container not ready for publishing") {
+		t.Errorf("expected container not ready error, got: %v", err)
+	}
+}
+
+func TestCreateAndPublishTextPostDirectly_APIError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text:            "Hello",
+		AutoPublishText: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for API error")
+	}
+}
+
+func TestCreateAndPublishTextPostDirectly_EmptyPostID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":""}`))
+
+	_, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text:            "Hello",
+		AutoPublishText: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for empty post ID in response")
+	}
+}
+
+func TestCreateAndPublishTextPostDirectly_MalformedResponse(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+
+	_, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text:            "Hello",
+		AutoPublishText: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for malformed response")
+	}
+}
+
+func TestCreateContainer_EmptyUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	// Clear token info to have empty user ID
+	client.mu.Lock()
+	client.tokenInfo.UserID = ""
+	client.mu.Unlock()
+
+	_, err := client.createContainer(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestCreateContainer_APIError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.createContainer(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for API error")
+	}
+}
+
+func TestCreateContainer_MalformedResponse(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+
+	_, err := client.createContainer(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for malformed response")
+	}
+}
+
+func TestCreateContainer_EmptyContainerID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":""}`))
+
+	_, err := client.createContainer(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for empty container ID in response")
+	}
+}
+
+func TestPublishContainer_EmptyContainerID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.publishContainer(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty container ID")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestPublishContainer_EmptyUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	client.mu.Lock()
+	client.tokenInfo.UserID = ""
+	client.mu.Unlock()
+
+	_, err := client.publishContainer(context.Background(), "container_1")
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestPublishContainer_APIError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.publishContainer(context.Background(), "container_1")
+	if err == nil {
+		t.Fatal("expected error for API error")
+	}
+}
+
+func TestPublishContainer_MalformedResponse(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+
+	_, err := client.publishContainer(context.Background(), "container_1")
+	if err == nil {
+		t.Fatal("expected error for malformed response")
+	}
+}
+
+func TestPublishContainer_EmptyPostID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"id":""}`))
+
+	_, err := client.publishContainer(context.Background(), "container_1")
+	if err == nil {
+		t.Fatal("expected error for empty post ID in response")
 	}
 }

--- a/posts_delete_test.go
+++ b/posts_delete_test.go
@@ -3,6 +3,7 @@ package threads
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -46,5 +47,268 @@ func TestDeletePost_NotFound(t *testing.T) {
 	}
 	if !IsAPIError(err) {
 		t.Errorf("expected APIError, got %T", err)
+	}
+}
+
+func TestDeletePostWithConfirmation_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "DELETE" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"success":true}`))
+			return
+		}
+		// GET requests for post and user info
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","owner":{"id":"12345"}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	confirmed := false
+	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), func(post *Post) bool {
+		confirmed = true
+		return true
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !confirmed {
+		t.Error("confirmation callback was not called")
+	}
+}
+
+func TestDeletePostWithConfirmation_Cancelled(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","text":"hello"}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), func(post *Post) bool {
+		return false // user cancels
+	})
+	if err == nil {
+		t.Fatal("expected error when user cancels deletion")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestDeletePostWithConfirmation_InvalidID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.DeletePostWithConfirmation(context.Background(), PostID(""), func(post *Post) bool {
+		return true
+	})
+	if err == nil {
+		t.Fatal("expected error for empty post ID")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestDeletePostWithConfirmation_NilCallback(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), nil)
+	if err == nil {
+		t.Fatal("expected error for nil callback")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestDeletePostWithConfirmation_GetPostError(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found","type":"OAuthException","code":100}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("nonexistent"), func(post *Post) bool {
+		return true
+	})
+	if err == nil {
+		t.Fatal("expected error when post not found")
+	}
+}
+
+func TestDeletePost_Forbidden(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "DELETE" {
+			w.WriteHeader(403)
+			_, _ = w.Write([]byte(`{"error":{"message":"access denied","type":"OAuthException","code":200}}`))
+			return
+		}
+		// GET requests for post and user info
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","owner":{"id":"12345"}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestDeletePost_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestDeletePost_ServerError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "DELETE" {
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"internal error","type":"OAuthException","code":2}}`))
+			return
+		}
+		// GET requests for post and user info
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","owner":{"id":"12345"}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestDeletePost_Delete404(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "DELETE" {
+			w.WriteHeader(404)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found","type":"OAuthException","code":100}}`))
+			return
+		}
+		// GET requests for post and user info
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","owner":{"id":"12345"}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	if err == nil {
+		t.Fatal("expected error for 404 DELETE")
+	}
+	// The DeletePost method returns a ValidationError for 404 on the DELETE call
+	if !strings.Contains(err.Error(), "not found") && !strings.Contains(err.Error(), "Post not found") {
+		t.Errorf("expected not found error, got: %v", err)
+	}
+}
+
+func TestDeletePost_WithLogger(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "DELETE" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"success":true}`))
+			return
+		}
+		// GET requests for post and user info
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","owner":{"id":"12345"}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.Logger = &noopLogger{}
+
+	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeletePost_MalformedDeleteResponse(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "DELETE" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`not json`))
+			return
+		}
+		// GET requests for post and user info
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","owner":{"id":"12345"}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	// Should succeed even with malformed response (200 status assumed success)
+	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeletePost_MalformedDeleteResponseWithLogger(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "DELETE" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`not json`))
+			return
+		}
+		// GET requests for post and user info
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"post_1","owner":{"id":"12345"}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.Logger = &noopLogger{}
+
+	// Should succeed even with malformed response and logger
+	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidatePostOwnership_DifferentUser(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if strings.HasPrefix(r.URL.Path, "/12345") {
+			// GetMe -> GetUser returns our user
+			_, _ = w.Write([]byte(`{"id":"12345","username":"me"}`))
+		} else {
+			// GetPost returns a post owned by someone else
+			_, _ = w.Write([]byte(`{"id":"post_1","username":"other_user"}`))
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	err := client.validatePostOwnership(context.Background(), ConvertToPostID("post_1"))
+	if err == nil {
+		t.Fatal("expected error for different user ownership")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
 	}
 }

--- a/posts_read_test.go
+++ b/posts_read_test.go
@@ -175,3 +175,302 @@ func TestGetUserGhostPosts_Success(t *testing.T) {
 		t.Errorf("expected 1 ghost post, got %d", len(resp.Data))
 	}
 }
+
+func TestGetUserMentions_InvalidUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.GetUserMentions(context.Background(), UserID(""), nil)
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestGetUserMentions_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestGetUserMentions_WithPagination(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		limit := r.URL.Query().Get("limit")
+		before := r.URL.Query().Get("before")
+		after := r.URL.Query().Get("after")
+		if limit != "10" {
+			t.Errorf("expected limit=10, got %s", limit)
+		}
+		if before != "cursor_before" {
+			t.Errorf("expected before=cursor_before, got %s", before)
+		}
+		if after != "cursor_after" {
+			t.Errorf("expected after=cursor_after, got %s", after)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data": [{"id": "1"}], "paging": {}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), &PaginationOptions{
+		Limit:  10,
+		Before: "cursor_before",
+		After:  "cursor_after",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetUserMentions_NotFound(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found","type":"OAuthException","code":100}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetUserMentions_Forbidden(t *testing.T) {
+	client := testClient(t, jsonHandler(403, `{"error":{"message":"access denied","type":"OAuthException","code":200}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestGetUserMentions_ServerError(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"internal error","type":"OAuthException","code":2}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestGetUserGhostPosts_InvalidUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.GetUserGhostPosts(context.Background(), UserID(""), nil)
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestGetUserGhostPosts_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.GetUserGhostPosts(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestGetUserGhostPosts_WithPagination(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		limit := r.URL.Query().Get("limit")
+		before := r.URL.Query().Get("before")
+		if limit != "5" {
+			t.Errorf("expected limit=5, got %s", limit)
+		}
+		if before != "cursor_abc" {
+			t.Errorf("expected before=cursor_abc, got %s", before)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data": [{"id": "1"}], "paging": {}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	_, err := client.GetUserGhostPosts(context.Background(), ConvertToUserID("12345"), &PaginationOptions{
+		Limit:  5,
+		Before: "cursor_abc",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetUserGhostPosts_NotFound(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found","type":"OAuthException","code":100}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetUserGhostPosts(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetUserGhostPosts_ServerError(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"internal error","type":"OAuthException","code":2}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetUserGhostPosts(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestGetPublishingLimits_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.GetPublishingLimits(context.Background())
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestGetPublishingLimits_EmptyUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	client.mu.Lock()
+	client.tokenInfo.UserID = ""
+	client.mu.Unlock()
+
+	_, err := client.GetPublishingLimits(context.Background())
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestGetPublishingLimits_APIError(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"internal error","type":"OAuthException","code":2}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetPublishingLimits(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestGetPublishingLimits_EmptyData(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[]}`))
+
+	_, err := client.GetPublishingLimits(context.Background())
+	if err == nil {
+		t.Fatal("expected error for empty data")
+	}
+}
+
+func TestGetPublishingLimits_MalformedResponse(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+
+	_, err := client.GetPublishingLimits(context.Background())
+	if err == nil {
+		t.Fatal("expected error for malformed response")
+	}
+}
+
+func TestGetUserPosts_WithPagination(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		limit := r.URL.Query().Get("limit")
+		before := r.URL.Query().Get("before")
+		after := r.URL.Query().Get("after")
+		if limit != "10" {
+			t.Errorf("expected limit=10, got %s", limit)
+		}
+		if before != "before_cursor" {
+			t.Errorf("expected before=before_cursor, got %s", before)
+		}
+		if after != "after_cursor" {
+			t.Errorf("expected after=after_cursor, got %s", after)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data": [{"id": "1"}], "paging": {}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	resp, err := client.GetUserPosts(context.Background(), ConvertToUserID("12345"), &PaginationOptions{
+		Limit:  10,
+		Before: "before_cursor",
+		After:  "after_cursor",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Errorf("expected 1 post, got %d", len(resp.Data))
+	}
+}
+
+func TestGetUserPostsWithOptions_WithTimeFilters(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		since := r.URL.Query().Get("since")
+		until := r.URL.Query().Get("until")
+		if since != "1700000000" {
+			t.Errorf("expected since=1700000000, got %s", since)
+		}
+		if until != "1700100000" {
+			t.Errorf("expected until=1700100000, got %s", until)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data": [{"id": "1"}], "paging": {}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	_, err := client.GetUserPostsWithOptions(context.Background(), ConvertToUserID("12345"), &PostsOptions{
+		Since: 1700000000,
+		Until: 1700100000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetUserPostsWithOptions_NotFound(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found","type":"OAuthException","code":100}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetUserPostsWithOptions(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetUserPostsWithOptions_Forbidden(t *testing.T) {
+	client := testClient(t, jsonHandler(403, `{"error":{"message":"access denied","type":"OAuthException","code":200}}`))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.GetUserPostsWithOptions(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}

--- a/posts_replies_test.go
+++ b/posts_replies_test.go
@@ -1,0 +1,276 @@
+package threads
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCreateReply_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("failed to parse form: %v", err)
+			}
+			if r.PostForm.Get("reply_to_id") != "parent_post_123" {
+				t.Errorf("expected reply_to_id=parent_post_123, got %s", r.PostForm.Get("reply_to_id"))
+			}
+			if r.PostForm.Get("media_type") != "TEXT" {
+				t.Errorf("expected media_type=TEXT, got %s", r.PostForm.Get("media_type"))
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/reply_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_post","text":"My reply","media_type":"TEXT"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	post, err := client.CreateReply(context.Background(), &PostContent{
+		Text:    "My reply",
+		ReplyTo: "parent_post_123",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "reply_post" {
+		t.Errorf("expected reply_post, got %s", post.ID)
+	}
+}
+
+func TestCreateReply_NilContent(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateReply(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil content")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateReply_EmptyReplyTo(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.CreateReply(context.Background(), &PostContent{
+		Text:    "My reply",
+		ReplyTo: "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty reply_to")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateReply_NotAuthenticated(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_ = client.ClearToken()
+
+	_, err := client.CreateReply(context.Background(), &PostContent{
+		Text:    "My reply",
+		ReplyTo: "parent_post_123",
+	})
+	if err == nil {
+		t.Fatal("expected error when not authenticated")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestCreateReply_ContainerCreateError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" {
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"Bad request","type":"OAuthException","code":100}}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateReply(context.Background(), &PostContent{
+		Text:    "My reply",
+		ReplyTo: "parent_post_123",
+	})
+	if err == nil {
+		t.Fatal("expected error when container creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create reply container") {
+		t.Errorf("expected reply container error, got: %v", err)
+	}
+}
+
+func TestCreateReply_DefaultMediaType(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("failed to parse form: %v", err)
+			}
+			// Default media type should be TEXT
+			if r.PostForm.Get("media_type") != "TEXT" {
+				t.Errorf("expected default media_type=TEXT, got %s", r.PostForm.Get("media_type"))
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/reply_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_post","text":"reply","media_type":"TEXT"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	// No MediaType set - should default to TEXT
+	post, err := client.CreateReply(context.Background(), &PostContent{
+		Text:    "reply",
+		ReplyTo: "parent_post_123",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "reply_post" {
+		t.Errorf("expected reply_post, got %s", post.ID)
+	}
+}
+
+func TestCreateReply_ContextCancelled(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads") {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_container"}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the reply delay
+
+	_, err := client.CreateReply(ctx, &PostContent{
+		Text:    "My reply",
+		ReplyTo: "parent_post_123",
+	})
+	// CreateReply creates container, then waits ReplyPublishDelay.
+	// If context is already cancelled, it should fail during the POST or the select.
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestReplyToPost_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_post"}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("failed to parse form: %v", err)
+			}
+			if r.PostForm.Get("reply_to_id") != "target_post" {
+				t.Errorf("expected reply_to_id=target_post, got %s", r.PostForm.Get("reply_to_id"))
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/reply_post"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_post","text":"reply text","media_type":"TEXT"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	post, err := client.ReplyToPost(context.Background(), ConvertToPostID("target_post"), &PostContent{
+		Text: "reply text",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if post.ID != "reply_post" {
+		t.Errorf("expected reply_post, got %s", post.ID)
+	}
+}
+
+func TestReplyToPost_InvalidPostID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.ReplyToPost(context.Background(), PostID(""), &PostContent{Text: "hello"})
+	if err == nil {
+		t.Fatal("expected error for empty post ID")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestReplyToPost_NilContent(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.ReplyToPost(context.Background(), ConvertToPostID("target_post"), nil)
+	if err == nil {
+		t.Fatal("expected error for nil content")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestCreateReply_PublishError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"publish failed","type":"OAuthException","code":100}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"reply_container"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	client.config.RetryConfig.MaxRetries = 0
+
+	_, err := client.CreateReply(context.Background(), &PostContent{
+		Text:    "My reply",
+		ReplyTo: "parent_post_123",
+	})
+	if err == nil {
+		t.Fatal("expected error when publish fails")
+	}
+	if !strings.Contains(err.Error(), "failed to publish reply") {
+		t.Errorf("expected publish error, got: %v", err)
+	}
+}

--- a/posts_validation_test.go
+++ b/posts_validation_test.go
@@ -1,0 +1,776 @@
+package threads
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTextPostContent_Nil(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(nil)
+	if err == nil {
+		t.Fatal("expected error for nil content")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateTextPostContent_Valid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Hello world",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTextPostContent_TooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longText := strings.Repeat("a", MaxTextLength+1)
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: longText,
+	})
+	if err == nil {
+		t.Fatal("expected error for text too long")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateTextPostContent_TooManyLinks(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	// 6 unique links exceeds the limit of 5
+	text := "https://a.com https://b.com https://c.com https://d.com https://e.com"
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:           text,
+		LinkAttachment: "https://f.com",
+	})
+	if err == nil {
+		t.Fatal("expected error for too many links")
+	}
+}
+
+func TestValidateTextPostContent_WithTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:     "Hello",
+		TopicTag: "golang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTextPostContent_InvalidTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:     "Hello",
+		TopicTag: "go.lang",
+	})
+	if err == nil {
+		t.Fatal("expected error for topic tag with period")
+	}
+}
+
+func TestValidateTextPostContent_WithCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:                    "Hello",
+		AllowlistedCountryCodes: []string{"US", "CA"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTextPostContent_InvalidCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:                    "Hello",
+		AllowlistedCountryCodes: []string{"USA"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid country code")
+	}
+}
+
+func TestValidateTextPostContent_GhostPostAsReply(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:        "Ghost",
+		IsGhostPost: true,
+		ReplyTo:     "some_post",
+	})
+	if err == nil {
+		t.Fatal("expected error for ghost post as reply")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateTextPostContent_GhostPostWithReplyApprovals(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:                 "Ghost",
+		IsGhostPost:          true,
+		EnableReplyApprovals: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for ghost post with reply approvals")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateTextPostContent_TextAttachmentWithPoll(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Hello",
+		TextAttachment: &TextAttachment{
+			Plaintext: "Some long text",
+		},
+		PollAttachment: &PollAttachment{
+			OptionA: "Yes",
+			OptionB: "No",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for text attachment with poll")
+	}
+}
+
+func TestValidateTextPostContent_DuplicateLinkAttachments(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:           "Hello",
+		LinkAttachment: "https://example.com",
+		TextAttachment: &TextAttachment{
+			Plaintext:         "Some long text",
+			LinkAttachmentURL: "https://other.com",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate link attachments")
+	}
+}
+
+func TestValidateTextPostContent_WithTextEntities(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Hello world spoiler here",
+		TextEntities: []TextEntity{
+			{EntityType: "SPOILER", Offset: 12, Length: 7},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTextPostContent_TooManyTextEntities(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	entities := make([]TextEntity, MaxTextEntities+1)
+	for i := range entities {
+		entities[i] = TextEntity{EntityType: "SPOILER", Offset: i * 5, Length: 3}
+	}
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text:         strings.Repeat("hello ", MaxTextEntities+2),
+		TextEntities: entities,
+	})
+	if err == nil {
+		t.Fatal("expected error for too many text entities")
+	}
+}
+
+func TestValidateTextPostContent_ValidGIFAttachment(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Check this GIF",
+		GIFAttachment: &GIFAttachment{
+			GIFID:    "abc123",
+			Provider: GIFProviderGiphy,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTextPostContent_InvalidGIFAttachment(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Check this GIF",
+		GIFAttachment: &GIFAttachment{
+			GIFID:    "",
+			Provider: GIFProviderGiphy,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty GIF ID")
+	}
+}
+
+func TestValidateImagePostContent_Nil(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(nil)
+	if err == nil {
+		t.Fatal("expected error for nil content")
+	}
+}
+
+func TestValidateImagePostContent_Valid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		Text:     "My image",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateImagePostContent_TextTooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longText := strings.Repeat("a", MaxTextLength+1)
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		Text:     longText,
+	})
+	if err == nil {
+		t.Fatal("expected error for text too long")
+	}
+}
+
+func TestValidateImagePostContent_InvalidURL(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "not-a-url",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestValidateImagePostContent_WithTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		TopicTag: "photography",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateImagePostContent_InvalidTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		TopicTag: "photo.graphy",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid topic tag")
+	}
+}
+
+func TestValidateImagePostContent_WithCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL:                "https://example.com/img.jpg",
+		AllowlistedCountryCodes: []string{"US", "GB"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateImagePostContent_InvalidCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL:                "https://example.com/img.jpg",
+		AllowlistedCountryCodes: []string{"TOOLONG"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid country code")
+	}
+}
+
+func TestValidateVideoPostContent_Nil(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(nil)
+	if err == nil {
+		t.Fatal("expected error for nil content")
+	}
+}
+
+func TestValidateVideoPostContent_Valid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVideoPostContent_TextTooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longText := strings.Repeat("a", MaxTextLength+1)
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+		Text:     longText,
+	})
+	if err == nil {
+		t.Fatal("expected error for text too long")
+	}
+}
+
+func TestValidateVideoPostContent_InvalidURL(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "ftp://invalid",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestValidateVideoPostContent_WithTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+		TopicTag: "video",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVideoPostContent_InvalidTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+		TopicTag: "vid&eo",
+	})
+	if err == nil {
+		t.Fatal("expected error for topic tag with ampersand")
+	}
+}
+
+func TestValidateVideoPostContent_WithCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL:                "https://example.com/vid.mp4",
+		AllowlistedCountryCodes: []string{"US"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVideoPostContent_InvalidCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL:                "https://example.com/vid.mp4",
+		AllowlistedCountryCodes: []string{"1A"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid country code")
+	}
+}
+
+func TestValidateCarouselPostContent_Nil(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(nil)
+	if err == nil {
+		t.Fatal("expected error for nil content")
+	}
+}
+
+func TestValidateCarouselPostContent_Valid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Text:     "Carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCarouselPostContent_TooFewChildren(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Text:     "Carousel",
+		Children: []string{"child_1"},
+	})
+	if err == nil {
+		t.Fatal("expected error for too few children")
+	}
+}
+
+func TestValidateCarouselPostContent_TooManyChildren(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	children := make([]string, MaxCarouselItems+1)
+	for i := range children {
+		children[i] = "child"
+	}
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Text:     "Carousel",
+		Children: children,
+	})
+	if err == nil {
+		t.Fatal("expected error for too many children")
+	}
+}
+
+func TestValidateCarouselPostContent_TextTooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longText := strings.Repeat("a", MaxTextLength+1)
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Text:     longText,
+		Children: []string{"child_1", "child_2"},
+	})
+	if err == nil {
+		t.Fatal("expected error for text too long")
+	}
+}
+
+func TestValidateCarouselPostContent_WithTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Children: []string{"child_1", "child_2"},
+		TopicTag: "carousel",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCarouselPostContent_InvalidTopicTag(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Children: []string{"child_1", "child_2"},
+		TopicTag: "carou.sel",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid topic tag")
+	}
+}
+
+func TestValidateCarouselPostContent_WithCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Children:                []string{"child_1", "child_2"},
+		AllowlistedCountryCodes: []string{"US", "CA"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCarouselPostContent_InvalidCountryCodes(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Children:                []string{"child_1", "child_2"},
+		AllowlistedCountryCodes: []string{"XYZ"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid country code")
+	}
+}
+
+func TestValidateCarouselChildren_Empty(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselChildren([]string{})
+	if err == nil {
+		t.Fatal("expected error for empty children")
+	}
+}
+
+func TestValidateCarouselChildren_Valid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselChildren([]string{"child_1", "child_2", "child_3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCarouselChildren_TooFew(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselChildren([]string{"child_1"})
+	if err == nil {
+		t.Fatal("expected error for too few children")
+	}
+}
+
+func TestValidateCarouselChildren_TooMany(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	children := make([]string, MaxCarouselItems+1)
+	for i := range children {
+		children[i] = "child"
+	}
+
+	err := client.ValidateCarouselChildren(children)
+	if err == nil {
+		t.Fatal("expected error for too many children")
+	}
+}
+
+func TestValidateCarouselChildren_EmptyChildID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselChildren([]string{"child_1", "", "child_3"})
+	if err == nil {
+		t.Fatal("expected error for empty child ID")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateCarouselChildren_WhitespaceChildID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselChildren([]string{"child_1", "   ", "child_3"})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only child ID")
+	}
+}
+
+func TestValidateTopicTag_Valid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTopicTag("golang")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTopicTag_Empty(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTopicTag("")
+	if err != nil {
+		t.Fatalf("unexpected error for empty tag: %v", err)
+	}
+}
+
+func TestValidateTopicTag_WithPeriod(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTopicTag("go.lang")
+	if err == nil {
+		t.Fatal("expected error for topic tag with period")
+	}
+}
+
+func TestValidateTopicTag_WithAmpersand(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTopicTag("go&lang")
+	if err == nil {
+		t.Fatal("expected error for topic tag with ampersand")
+	}
+}
+
+func TestValidateCountryCodes_Valid(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCountryCodes([]string{"US", "CA", "GB"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCountryCodes_Empty(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCountryCodes([]string{})
+	if err != nil {
+		t.Fatalf("unexpected error for empty codes: %v", err)
+	}
+}
+
+func TestValidateCountryCodes_InvalidLength(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCountryCodes([]string{"USA"})
+	if err == nil {
+		t.Fatal("expected error for 3-character code")
+	}
+}
+
+func TestValidateCountryCodes_NonAlphabetic(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCountryCodes([]string{"1A"})
+	if err == nil {
+		t.Fatal("expected error for non-alphabetic code")
+	}
+}
+
+func TestValidateTextPostContent_WithTextAttachment(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Hello",
+		TextAttachment: &TextAttachment{
+			Plaintext: "Some extended text content here.",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTextPostContent_TextAttachmentTooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longPlaintext := strings.Repeat("a", MaxTextAttachmentLength+1)
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Hello",
+		TextAttachment: &TextAttachment{
+			Plaintext: longPlaintext,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for text attachment too long")
+	}
+}
+
+func TestValidateImagePostContent_WithTextEntities(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		Text:     "Hello spoiler here",
+		TextEntities: []TextEntity{
+			{EntityType: "SPOILER", Offset: 6, Length: 7},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVideoPostContent_WithTextEntities(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+		Text:     "Hello spoiler here",
+		TextEntities: []TextEntity{
+			{EntityType: "SPOILER", Offset: 6, Length: 7},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCarouselPostContent_WithTextEntities(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Children: []string{"child_1", "child_2"},
+		Text:     "Hello spoiler here",
+		TextEntities: []TextEntity{
+			{EntityType: "SPOILER", Offset: 6, Length: 7},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateImagePostContent_TooManyLinks(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	text := "https://a.com https://b.com https://c.com https://d.com https://e.com https://f.com"
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		Text:     text,
+	})
+	if err == nil {
+		t.Fatal("expected error for too many links")
+	}
+}
+
+func TestValidateVideoPostContent_TooManyLinks(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	text := "https://a.com https://b.com https://c.com https://d.com https://e.com https://f.com"
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+		Text:     text,
+	})
+	if err == nil {
+		t.Fatal("expected error for too many links")
+	}
+}
+
+func TestValidateCarouselPostContent_TooManyLinks(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	text := "https://a.com https://b.com https://c.com https://d.com https://e.com https://f.com"
+	err := client.ValidateCarouselPostContent(&CarouselPostContent{
+		Children: []string{"child_1", "child_2"},
+		Text:     text,
+	})
+	if err == nil {
+		t.Fatal("expected error for too many links")
+	}
+}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -2,6 +2,8 @@ package threads
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -27,6 +29,14 @@ func TestRateLimiter_MarkRateLimited(t *testing.T) {
 	}
 }
 
+func TestRateLimiter_MarkRateLimited_WithLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, Logger: &noopLogger{}})
+	rl.MarkRateLimited(time.Now().Add(30 * time.Second))
+	if !rl.IsRateLimited() {
+		t.Error("expected to be rate limited")
+	}
+}
+
 func TestRateLimiter_WaitRespectsContext(t *testing.T) {
 	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
 	rl.MarkRateLimited(time.Now().Add(10 * time.Second))
@@ -37,6 +47,65 @@ func TestRateLimiter_WaitRespectsContext(t *testing.T) {
 	err := rl.Wait(ctx)
 	if err == nil {
 		t.Fatal("expected context timeout error")
+	}
+}
+
+func TestRateLimiter_WaitAfterReset(t *testing.T) {
+	// When resetTime is in the past, Wait should return immediately
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	rl.mu.Lock()
+	rl.resetTime = time.Now().Add(-time.Second) // Already past
+	rl.rateLimited = true
+	rl.mu.Unlock()
+
+	err := rl.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRateLimiter_WaitNotRateLimited(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	// Not rate limited, should return immediately
+	err := rl.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRateLimiter_WaitWithBackoff(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{
+		InitialLimit:      100,
+		BackoffMultiplier: 2.0,
+		MaxBackoff:        5 * time.Second,
+	})
+	// Set up recently rate limited state to trigger backoff
+	rl.mu.Lock()
+	rl.rateLimited = true
+	rl.lastRateLimitTime = time.Now() // recently rate limited
+	rl.lastRequestTime = time.Now()   // recently requested
+	rl.resetTime = time.Now().Add(50 * time.Millisecond)
+	rl.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := rl.Wait(ctx)
+	// Should either succeed (backoff < 200ms) or timeout
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRateLimiter_WaitWithResetInPast(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, Logger: &noopLogger{}})
+	rl.mu.Lock()
+	rl.resetTime = time.Now().Add(-time.Minute) // already reset
+	rl.mu.Unlock()
+
+	err := rl.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -57,6 +126,15 @@ func TestRateLimiter_UpdateFromHeaders(t *testing.T) {
 	}
 }
 
+func TestRateLimiter_UpdateFromHeaders_Nil(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	rl.UpdateFromHeaders(nil)
+	status := rl.GetStatus()
+	if status.Limit != 100 {
+		t.Errorf("expected limit unchanged at 100, got %d", status.Limit)
+	}
+}
+
 func TestRateLimiter_IsNearLimit(t *testing.T) {
 	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
 	rl.UpdateFromHeaders(&RateLimitInfo{Limit: 100, Remaining: 10})
@@ -69,12 +147,26 @@ func TestRateLimiter_IsNearLimit(t *testing.T) {
 	}
 }
 
+func TestRateLimiter_IsNearLimit_ZeroLimit(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	rl.mu.Lock()
+	rl.limit = 0
+	rl.mu.Unlock()
+	if rl.IsNearLimit(0.8) {
+		t.Error("expected not near limit with zero limit")
+	}
+}
+
 func TestRateLimiter_Reset(t *testing.T) {
 	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
 	rl.MarkRateLimited(time.Now().Add(time.Hour))
+	_ = rl.QueueRequest(context.Background())
 	rl.Reset()
 	if rl.IsRateLimited() {
 		t.Error("expected not rate limited after reset")
+	}
+	if rl.GetQueueLength() != 0 {
+		t.Errorf("expected queue length 0 after reset, got %d", rl.GetQueueLength())
 	}
 }
 
@@ -86,5 +178,248 @@ func TestRateLimiter_QueueRequest(t *testing.T) {
 	err := rl.QueueRequest(context.Background())
 	if err == nil {
 		t.Fatal("expected error when queue is full")
+	}
+}
+
+func TestRateLimiter_QueueRequest_ContextCanceled(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, QueueSize: 1})
+	_ = rl.QueueRequest(context.Background()) // fill queue
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	err := rl.QueueRequest(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestRateLimiter_GetQueueLength(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, QueueSize: 10})
+	if rl.GetQueueLength() != 0 {
+		t.Errorf("expected 0, got %d", rl.GetQueueLength())
+	}
+	_ = rl.QueueRequest(context.Background())
+	if rl.GetQueueLength() != 1 {
+		t.Errorf("expected 1, got %d", rl.GetQueueLength())
+	}
+	_ = rl.QueueRequest(context.Background())
+	if rl.GetQueueLength() != 2 {
+		t.Errorf("expected 2, got %d", rl.GetQueueLength())
+	}
+}
+
+func TestRateLimiter_ProcessQueue(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, QueueSize: 10})
+
+	// Add items to queue
+	_ = rl.QueueRequest(context.Background())
+	_ = rl.QueueRequest(context.Background())
+
+	var processed int32
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		_ = rl.ProcessQueue(ctx, func() error {
+			atomic.AddInt32(&processed, 1)
+			return nil
+		})
+	}()
+
+	// Wait for processing
+	time.Sleep(100 * time.Millisecond)
+	if atomic.LoadInt32(&processed) != 2 {
+		t.Errorf("expected 2 processed, got %d", atomic.LoadInt32(&processed))
+	}
+}
+
+func TestRateLimiter_ProcessQueue_WithError(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, QueueSize: 10, Logger: &noopLogger{}})
+	_ = rl.QueueRequest(context.Background())
+	_ = rl.QueueRequest(context.Background())
+
+	var processed int32
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		_ = rl.ProcessQueue(ctx, func() error {
+			count := atomic.AddInt32(&processed, 1)
+			if count == 1 {
+				return errors.New("test error")
+			}
+			return nil
+		})
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	// Both should be processed even though first errored
+	if atomic.LoadInt32(&processed) != 2 {
+		t.Errorf("expected 2 processed (even with error), got %d", atomic.LoadInt32(&processed))
+	}
+}
+
+func TestRateLimiter_ProcessQueue_ContextCancel(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, QueueSize: 10})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := rl.ProcessQueue(ctx, func() error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestRateLimiter_CalculateBackoff(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{
+		InitialLimit:      100,
+		BackoffMultiplier: 2.0,
+		MaxBackoff:        5 * time.Minute,
+	})
+
+	// When last request was recent, should apply multiplier
+	rl.mu.Lock()
+	rl.lastRequestTime = time.Now()
+	rl.mu.Unlock()
+
+	backoff := rl.calculateBackoff()
+	if backoff != 2*time.Second {
+		t.Errorf("expected 2s backoff, got %v", backoff)
+	}
+}
+
+func TestRateLimiter_CalculateBackoff_NoRecentRequest(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{
+		InitialLimit:      100,
+		BackoffMultiplier: 2.0,
+		MaxBackoff:        5 * time.Minute,
+	})
+
+	// When last request was long ago, should use base delay
+	rl.mu.Lock()
+	rl.lastRequestTime = time.Now().Add(-2 * time.Minute)
+	rl.mu.Unlock()
+
+	backoff := rl.calculateBackoff()
+	if backoff != time.Second {
+		t.Errorf("expected 1s base delay, got %v", backoff)
+	}
+}
+
+func TestRateLimiter_CalculateBackoff_MaxBackoff(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{
+		InitialLimit:      100,
+		BackoffMultiplier: 1000.0, // very high multiplier
+		MaxBackoff:        3 * time.Second,
+	})
+
+	rl.mu.Lock()
+	rl.lastRequestTime = time.Now()
+	rl.mu.Unlock()
+
+	backoff := rl.calculateBackoff()
+	if backoff > 3*time.Second {
+		t.Errorf("expected backoff capped at 3s, got %v", backoff)
+	}
+}
+
+func TestRateLimiter_LogRateLimitReset_NilLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	// Should not panic
+	rl.logRateLimitReset()
+}
+
+func TestRateLimiter_LogRateLimitReset_WithLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, Logger: &noopLogger{}})
+	rl.logRateLimitReset()
+}
+
+func TestRateLimiter_LogQueueProcessError_NilLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	// Should not panic
+	rl.logQueueProcessError(errors.New("test"))
+}
+
+func TestRateLimiter_LogQueueProcessError_WithLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, Logger: &noopLogger{}})
+	rl.logQueueProcessError(errors.New("test"))
+}
+
+func TestRateLimiter_LogRateLimitUpdate_NilLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	rl.logRateLimitUpdate(&RateLimitInfo{Limit: 100, Remaining: 50})
+}
+
+func TestRateLimiter_LogRateLimitUpdate_WithLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, Logger: &noopLogger{}})
+	rl.logRateLimitUpdate(&RateLimitInfo{Limit: 100, Remaining: 50})
+}
+
+func TestRateLimiter_LogRateLimitWait_NilLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100})
+	rl.logRateLimitWait(5 * time.Second)
+}
+
+func TestRateLimiter_LogRateLimitWait_WithLogger(t *testing.T) {
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, Logger: &noopLogger{}})
+	rl.logRateLimitWait(5 * time.Second)
+}
+
+func TestRateLimiter_DefaultConfig(t *testing.T) {
+	// Test defaults get applied when zero values given
+	rl := NewRateLimiter(&RateLimiterConfig{})
+	status := rl.GetStatus()
+	if status.Limit != 100 {
+		t.Errorf("expected default limit 100, got %d", status.Limit)
+	}
+}
+
+func TestRateLimiter_WaitCompletesAfterReset(t *testing.T) {
+	// Rate limited but reset time is very soon, so Wait completes
+	rl := NewRateLimiter(&RateLimiterConfig{InitialLimit: 100, Logger: &noopLogger{}})
+	rl.mu.Lock()
+	rl.rateLimited = true
+	rl.lastRateLimitTime = time.Now().Add(-2 * time.Minute) // not recent
+	rl.resetTime = time.Now().Add(50 * time.Millisecond)
+	rl.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := rl.Wait(ctx)
+	if err != nil {
+		t.Fatalf("expected Wait to complete successfully, got: %v", err)
+	}
+	// After Wait completes, should no longer be rate limited
+	if rl.IsRateLimited() {
+		t.Error("expected not rate limited after Wait completes")
+	}
+}
+
+func TestRateLimiter_WaitWithFrequentRateLimiting(t *testing.T) {
+	// Test the branch where lastRateLimitTime is recent (< 1 minute) to trigger backoff
+	rl := NewRateLimiter(&RateLimiterConfig{
+		InitialLimit:      100,
+		BackoffMultiplier: 1.5,
+		MaxBackoff:        100 * time.Millisecond,
+		Logger:            &noopLogger{},
+	})
+	rl.mu.Lock()
+	rl.rateLimited = true
+	rl.lastRateLimitTime = time.Now()                    // recently rate limited
+	rl.lastRequestTime = time.Now()                      // recent request
+	rl.resetTime = time.Now().Add(20 * time.Millisecond) // reset soon
+	rl.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := rl.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/replies_test.go
+++ b/replies_test.go
@@ -2,6 +2,7 @@ package threads
 
 import (
 	"context"
+	"net/http"
 	"testing"
 )
 
@@ -31,6 +32,108 @@ func TestGetReplies_InvalidPostID(t *testing.T) {
 	}
 }
 
+func TestGetReplies_WithOptions(t *testing.T) {
+	reverse := true
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("limit") != "10" {
+			t.Errorf("expected limit=10, got %s", q.Get("limit"))
+		}
+		if q.Get("before") != "before_cursor" {
+			t.Errorf("expected before=before_cursor, got %s", q.Get("before"))
+		}
+		if q.Get("after") != "after_cursor" {
+			t.Errorf("expected after=after_cursor, got %s", q.Get("after"))
+		}
+		if q.Get("reverse") != "true" {
+			t.Errorf("expected reverse=true, got %s", q.Get("reverse"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.GetReplies(context.Background(), ConvertToPostID("post_1"), &RepliesOptions{
+		Limit:   10,
+		Before:  "before_cursor",
+		After:   "after_cursor",
+		Reverse: &reverse,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetReplies_LimitTooLarge(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetReplies(context.Background(), ConvertToPostID("post_1"), &RepliesOptions{Limit: 101})
+	if err == nil {
+		t.Fatal("expected error for limit > 100")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestBuildRepliesParams_NilOpts(t *testing.T) {
+	params, err := buildRepliesParams(nil, 100, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.Get("fields") == "" {
+		t.Error("expected fields parameter")
+	}
+}
+
+func TestBuildRepliesParams_AllOptions(t *testing.T) {
+	reverse := false
+	params, err := buildRepliesParams(&RepliesOptions{
+		Limit:   50,
+		Before:  "b",
+		After:   "a",
+		Reverse: &reverse,
+	}, 100, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.Get("limit") != "50" {
+		t.Errorf("expected limit=50, got %s", params.Get("limit"))
+	}
+	if params.Get("before") != "b" {
+		t.Errorf("expected before=b, got %s", params.Get("before"))
+	}
+	if params.Get("after") != "a" {
+		t.Errorf("expected after=a, got %s", params.Get("after"))
+	}
+	if params.Get("reverse") != "false" {
+		t.Errorf("expected reverse=false, got %s", params.Get("reverse"))
+	}
+}
+
+func TestFetchRepliesData_404(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found"}}`))
+	_, err := client.fetchRepliesData("/test/replies", nil, ConvertToPostID("post_1"), "replies")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestFetchRepliesData_403(t *testing.T) {
+	client := testClient(t, jsonHandler(403, `{"error":{"message":"forbidden"}}`))
+	_, err := client.fetchRepliesData("/test/replies", nil, ConvertToPostID("post_1"), "replies")
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+}
+
+func TestFetchRepliesData_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.fetchRepliesData("/test/replies", nil, ConvertToPostID("post_1"), "replies")
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
 func TestGetConversation_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{
 		"data": [{"id": "msg_1", "text": "Thread message"}],
@@ -43,6 +146,34 @@ func TestGetConversation_Success(t *testing.T) {
 	}
 	if len(resp.Data) != 1 {
 		t.Errorf("expected 1 message, got %d", len(resp.Data))
+	}
+}
+
+func TestGetConversation_InvalidPostID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetConversation(context.Background(), PostID(""), nil)
+	if err == nil {
+		t.Fatal("expected error for empty post ID")
+	}
+}
+
+func TestGetConversation_WithOptions(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[{"id":"1"}],"paging":{}}`))
+	_, err := client.GetConversation(context.Background(), ConvertToPostID("post_1"), &RepliesOptions{
+		Limit:  20,
+		Before: "b",
+		After:  "a",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetConversation_LimitTooLarge(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetConversation(context.Background(), ConvertToPostID("post_1"), &RepliesOptions{Limit: 101})
+	if err == nil {
+		t.Fatal("expected error for limit > 100")
 	}
 }
 
@@ -62,9 +193,96 @@ func TestHideReply_InvalidID(t *testing.T) {
 	}
 }
 
+func TestHideReply_404(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(404)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	err := client.HideReply(context.Background(), ConvertToPostID("reply_1"))
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestHideReply_403(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(403)
+			_, _ = w.Write([]byte(`{"error":{"message":"forbidden"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	err := client.HideReply(context.Background(), ConvertToPostID("reply_1"))
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+}
+
+func TestHideReply_500(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"server error"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	err := client.HideReply(context.Background(), ConvertToPostID("reply_1"))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
 func TestUnhideReply_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{"success":true}`))
 	err := client.UnhideReply(context.Background(), ConvertToPostID("reply_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnhideReply_InvalidID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.UnhideReply(context.Background(), PostID(""))
+	if err == nil {
+		t.Fatal("expected error for empty reply ID")
+	}
+}
+
+func TestManageReplyVisibility_UnparseableBody(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`not json`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	config := testClientConfig(t, http.HandlerFunc(handler))
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+	// Should still succeed (200 status) even with unparseable body
+	err := client.HideReply(context.Background(), ConvertToPostID("reply_1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,6 +303,83 @@ func TestGetPendingReplies_Success(t *testing.T) {
 	}
 }
 
+func TestGetPendingReplies_InvalidPostID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPendingReplies(context.Background(), PostID(""), nil)
+	if err == nil {
+		t.Fatal("expected error for empty post ID")
+	}
+}
+
+func TestGetPendingReplies_WithOptions(t *testing.T) {
+	reverse := true
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("limit") != "5" {
+			t.Errorf("expected limit=5, got %s", q.Get("limit"))
+		}
+		if q.Get("before") != "b" {
+			t.Errorf("expected before=b, got %s", q.Get("before"))
+		}
+		if q.Get("after") != "a" {
+			t.Errorf("expected after=a, got %s", q.Get("after"))
+		}
+		if q.Get("reverse") != "true" {
+			t.Errorf("expected reverse=true, got %s", q.Get("reverse"))
+		}
+		if q.Get("approval_status") != "pending" {
+			t.Errorf("expected approval_status=pending, got %s", q.Get("approval_status"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.GetPendingReplies(context.Background(), ConvertToPostID("post_1"), &PendingRepliesOptions{
+		Limit:          5,
+		Before:         "b",
+		After:          "a",
+		Reverse:        &reverse,
+		ApprovalStatus: ApprovalStatusPending,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetPendingReplies_IgnoredApprovalStatus(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[],"paging":{}}`))
+	_, err := client.GetPendingReplies(context.Background(), ConvertToPostID("post_1"), &PendingRepliesOptions{
+		ApprovalStatus: ApprovalStatusIgnored,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetPendingReplies_InvalidApprovalStatus(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPendingReplies(context.Background(), ConvertToPostID("post_1"), &PendingRepliesOptions{
+		ApprovalStatus: "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid approval status")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestGetPendingReplies_LimitTooLarge(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPendingReplies(context.Background(), ConvertToPostID("post_1"), &PendingRepliesOptions{
+		Limit: 101,
+	})
+	if err == nil {
+		t.Fatal("expected error for limit > 100")
+	}
+}
+
 func TestApprovePendingReply_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{"success":true}`))
 	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
@@ -93,9 +388,206 @@ func TestApprovePendingReply_Success(t *testing.T) {
 	}
 }
 
+func TestApprovePendingReply_InvalidID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.ApprovePendingReply(context.Background(), PostID(""))
+	if err == nil {
+		t.Fatal("expected error for empty reply ID")
+	}
+}
+
+func TestApprovePendingReply_404(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(404)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestApprovePendingReply_403(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(403)
+			_, _ = w.Write([]byte(`{"error":{"message":"forbidden"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+}
+
+func TestApprovePendingReply_500(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"server error"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
 func TestIgnorePendingReply_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{"success":true}`))
 	err := client.IgnorePendingReply(context.Background(), ConvertToPostID("pending_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIgnorePendingReply_InvalidID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	err := client.IgnorePendingReply(context.Background(), PostID(""))
+	if err == nil {
+		t.Fatal("expected error for empty reply ID")
+	}
+}
+
+func TestManagePendingReply_UnparseableBody(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`not json`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	config := testClientConfig(t, http.HandlerFunc(handler))
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagePendingReply_WithLogger(t *testing.T) {
+	handler := jsonHandler(200, `{"success":true}`)
+	config := testClientConfig(t, handler)
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManageReplyVisibility_WithLogger(t *testing.T) {
+	handler := jsonHandler(200, `{"success":true}`)
+	config := testClientConfig(t, handler)
+	config.Logger = &noopLogger{}
+	client := testClientWithConfig(t, config)
+	err := client.HideReply(context.Background(), ConvertToPostID("reply_1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchRepliesData_Success(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{
+		"data": [{"id":"r1","text":"reply"}],
+		"paging": {"cursors":{"after":"c1"}}
+	}`))
+	resp, err := client.fetchRepliesData("/test/replies", nil, ConvertToPostID("post_1"), "replies")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Errorf("expected 1 reply, got %d", len(resp.Data))
+	}
+}
+
+func TestFetchRepliesData_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+	_, err := client.fetchRepliesData("/test/replies", nil, ConvertToPostID("post_1"), "replies")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestGetReplies_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetReplies(context.Background(), ConvertToPostID("post_1"), nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestGetConversation_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetConversation(context.Background(), ConvertToPostID("post_1"), nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestGetPendingReplies_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetPendingReplies(context.Background(), ConvertToPostID("post_1"), nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestManageReplyVisibility_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	err := client.HideReply(context.Background(), ConvertToPostID("reply_1"))
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestManagePendingReply_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestManagePendingReply_EmptyBody(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			// Empty body
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	err := client.ApprovePendingReply(context.Background(), ConvertToPostID("pending_1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/search_test.go
+++ b/search_test.go
@@ -51,3 +51,141 @@ func TestKeywordSearch_WithOptions(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestKeywordSearch_WithAllOptions(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("search_mode") != "KEYWORD" {
+			t.Errorf("expected search_mode=KEYWORD, got %s", q.Get("search_mode"))
+		}
+		if q.Get("media_type") != "IMAGE" {
+			t.Errorf("expected media_type=IMAGE, got %s", q.Get("media_type"))
+		}
+		if q.Get("author_username") != "testuser" {
+			t.Errorf("expected author_username=testuser, got %s", q.Get("author_username"))
+		}
+		if q.Get("limit") != "10" {
+			t.Errorf("expected limit=10, got %s", q.Get("limit"))
+		}
+		if q.Get("since") != "1688540400" {
+			t.Errorf("expected since=1688540400, got %s", q.Get("since"))
+		}
+		if q.Get("until") != "1700000000" {
+			t.Errorf("expected until=1700000000, got %s", q.Get("until"))
+		}
+		if q.Get("before") != "b" {
+			t.Errorf("expected before=b, got %s", q.Get("before"))
+		}
+		if q.Get("after") != "a" {
+			t.Errorf("expected after=a, got %s", q.Get("after"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		SearchMode:     SearchModeKeyword,
+		MediaType:      "IMAGE",
+		AuthorUsername: "testuser",
+		Limit:          10,
+		Since:          1688540400,
+		Until:          1700000000,
+		Before:         "b",
+		After:          "a",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestKeywordSearch_InvalidMediaType(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		MediaType: "AUDIO",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid media type")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestKeywordSearch_LimitTooLarge(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		Limit: 101,
+	})
+	if err == nil {
+		t.Fatal("expected error for limit > 100")
+	}
+}
+
+func TestKeywordSearch_InvalidSinceTimestamp(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		Since: 100, // way too early
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid since timestamp")
+	}
+}
+
+func TestKeywordSearch_AuthorUsernameWithAt(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("author_username") != "user" {
+			t.Errorf("expected author_username=user (without @), got %s", q.Get("author_username"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		AuthorUsername: "@user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestKeywordSearch_EmptyAuthorUsername(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		AuthorUsername: "@",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty author username after trimming @")
+	}
+}
+
+func TestKeywordSearch_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.KeywordSearch(context.Background(), "test", nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestKeywordSearch_VideoMediaType(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[],"paging":{}}`))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		MediaType: "video", // lowercase should be uppercased
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestKeywordSearch_TextMediaType(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"data":[],"paging":{}}`))
+	_, err := client.KeywordSearch(context.Background(), "test", &SearchOptions{
+		MediaType: "text",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -65,6 +65,79 @@ func newTestHTTPClient(t *testing.T, handler http.Handler, retryConfig *RetryCon
 	return NewHTTPClient(config, nil)
 }
 
+// testClientConfig creates a Config pointed at a test server.
+func testClientConfig(t *testing.T, handler http.Handler) *Config {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	config := &Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	config.BaseURL = server.URL
+	return config
+}
+
+// testClientWithConfig creates a *Client using the provided config.
+func testClientWithConfig(t *testing.T, config *Config) *Client {
+	t.Helper()
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("testClientWithConfig: %v", err)
+	}
+
+	err = client.SetTokenInfo(&TokenInfo{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+		UserID:      "12345",
+		CreatedAt:   time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("testClientWithConfig SetTokenInfo: %v", err)
+	}
+
+	return client
+}
+
+// newBareClient creates a minimal *Client without an HTTP server for testing pure logic.
+func newBareClient(t *testing.T) *Client {
+	t.Helper()
+	config := NewConfig()
+	config.ClientID = "test-client-id"
+	config.ClientSecret = "test-client-secret"
+	config.RedirectURI = "https://example.com/callback"
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("newBareClient: %v", err)
+	}
+	return client
+}
+
+// testClientNoAuth creates a *Client without a token set (unauthenticated).
+func testClientNoAuth(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	config := &Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	config.BaseURL = server.URL
+
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("testClientNoAuth: %v", err)
+	}
+	return client
+}
+
 // noopLogger is a no-op Logger implementation for tests.
 type noopLogger struct{}
 

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,77 @@
+package threads
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTimeMarshalJSON(t *testing.T) {
+	now := time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
+	threadsTime := &Time{Time: now}
+
+	data, err := threadsTime.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+
+	// Should produce a valid JSON string in RFC3339 format
+	var result string
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// Parse the result back
+	parsed, err := time.Parse(time.RFC3339, result)
+	if err != nil {
+		t.Fatalf("Failed to parse RFC3339 time: %v", err)
+	}
+
+	if !parsed.Equal(now) {
+		t.Errorf("Expected time %v, got %v", now, parsed)
+	}
+}
+
+func TestTimeMarshalJSONRoundTrip(t *testing.T) {
+	original := &Time{Time: time.Date(2024, 6, 15, 14, 30, 45, 0, time.UTC)}
+
+	// Marshal
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Unmarshal back
+	var result Time
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !result.Time.Equal(original.Time) {
+		t.Errorf("Round trip failed: expected %v, got %v", original.Time, result.Time)
+	}
+}
+
+func TestTimeMarshalJSON_InStruct(t *testing.T) {
+	type TestStruct struct {
+		Timestamp Time `json:"timestamp"`
+	}
+
+	ts := TestStruct{
+		Timestamp: Time{Time: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+
+	data, err := json.Marshal(ts)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var result TestStruct
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !result.Timestamp.Time.Equal(ts.Timestamp.Time) {
+		t.Errorf("Expected %v, got %v", ts.Timestamp.Time, result.Timestamp.Time)
+	}
+}

--- a/users_test.go
+++ b/users_test.go
@@ -31,6 +31,30 @@ func TestGetUser_InvalidID(t *testing.T) {
 	}
 }
 
+func TestGetUser_404(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found"}}`))
+	_, err := client.GetUser(context.Background(), ConvertToUserID("99999"))
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetUser_403(t *testing.T) {
+	client := testClient(t, jsonHandler(403, `{"error":{"message":"forbidden"}}`))
+	_, err := client.GetUser(context.Background(), ConvertToUserID("99999"))
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+}
+
+func TestGetUser_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.GetUser(context.Background(), ConvertToUserID("12345"))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
 func TestGetMe_Success(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{"id":"12345","username":"me","name":"My Name"}`))
 
@@ -40,6 +64,24 @@ func TestGetMe_Success(t *testing.T) {
 	}
 	if user.Username != "me" {
 		t.Errorf("expected 'me', got %s", user.Username)
+	}
+}
+
+func TestGetMe_NoUserID(t *testing.T) {
+	// Create a client with no user ID in token info
+	handler := jsonHandler(200, `{"id":"12345","username":"me"}`)
+	client := testClient(t, handler)
+	// Clear the user ID from token info
+	client.mu.Lock()
+	client.tokenInfo.UserID = ""
+	client.mu.Unlock()
+
+	_, err := client.GetMe(context.Background())
+	if err == nil {
+		t.Fatal("expected error when user ID is not available")
+	}
+	if !IsAuthenticationError(err) {
+		t.Errorf("expected AuthenticationError, got %T", err)
 	}
 }
 
@@ -71,6 +113,39 @@ func TestLookupPublicProfile_EmptyUsername(t *testing.T) {
 	}
 }
 
+func TestLookupPublicProfile_WithAtSymbol(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		username := r.URL.Query().Get("username")
+		if username != "testuser" {
+			t.Errorf("expected username without @, got %s", username)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"username":"testuser","name":"Test"}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.LookupPublicProfile(context.Background(), "@testuser")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLookupPublicProfile_404(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found"}}`))
+	_, err := client.LookupPublicProfile(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestLookupPublicProfile_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.LookupPublicProfile(context.Background(), "user")
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
 func TestGetUserFields_Success(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		fields := r.URL.Query().Get("fields")
@@ -89,5 +164,340 @@ func TestGetUserFields_Success(t *testing.T) {
 	}
 	if user.ID != "12345" {
 		t.Errorf("expected 12345, got %s", user.ID)
+	}
+}
+
+func TestGetUserFields_InvalidID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetUserFields(context.Background(), UserID(""), []string{"id"})
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestGetUserFields_DefaultFields(t *testing.T) {
+	// When no fields are specified, defaults should be used
+	client := testClient(t, jsonHandler(200, `{"id":"12345","username":"testuser"}`))
+	user, err := client.GetUserFields(context.Background(), ConvertToUserID("12345"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.ID != "12345" {
+		t.Errorf("expected 12345, got %s", user.ID)
+	}
+}
+
+func TestGetUserFields_InvalidFields(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetUserFields(context.Background(), ConvertToUserID("12345"), []string{"invalid_field"})
+	if err == nil {
+		t.Fatal("expected error for invalid fields")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestGetUserFields_404(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found"}}`))
+	_, err := client.GetUserFields(context.Background(), ConvertToUserID("99999"), []string{"id"})
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetUserFields_403(t *testing.T) {
+	client := testClient(t, jsonHandler(403, `{"error":{"message":"forbidden"}}`))
+	_, err := client.GetUserFields(context.Background(), ConvertToUserID("99999"), []string{"id"})
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+}
+
+func TestGetUserFields_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.GetUserFields(context.Background(), ConvertToUserID("12345"), []string{"id"})
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestGetPublicProfilePosts_Success(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{
+		"data": [{"id":"1","text":"Hello"},{"id":"2","text":"World"}],
+		"paging": {"cursors":{"after":"cursor1"}}
+	}`))
+
+	resp, err := client.GetPublicProfilePosts(context.Background(), "testuser", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 posts, got %d", len(resp.Data))
+	}
+}
+
+func TestGetPublicProfilePosts_EmptyUsername(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPublicProfilePosts(context.Background(), "", nil)
+	if err == nil {
+		t.Fatal("expected error for empty username")
+	}
+}
+
+func TestGetPublicProfilePosts_WithAtSymbol(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		username := r.URL.Query().Get("username")
+		if username != "testuser" {
+			t.Errorf("expected username without @, got %s", username)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.GetPublicProfilePosts(context.Background(), "@testuser", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetPublicProfilePosts_WithOptions(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("limit") != "10" {
+			t.Errorf("expected limit=10, got %s", q.Get("limit"))
+		}
+		if q.Get("before") != "cursor_before" {
+			t.Errorf("expected before=cursor_before, got %s", q.Get("before"))
+		}
+		if q.Get("after") != "cursor_after" {
+			t.Errorf("expected after=cursor_after, got %s", q.Get("after"))
+		}
+		if q.Get("since") != "1000000" {
+			t.Errorf("expected since=1000000, got %s", q.Get("since"))
+		}
+		if q.Get("until") != "2000000" {
+			t.Errorf("expected until=2000000, got %s", q.Get("until"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.GetPublicProfilePosts(context.Background(), "user", &PostsOptions{
+		Limit:  10,
+		Before: "cursor_before",
+		After:  "cursor_after",
+		Since:  1000000,
+		Until:  2000000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetPublicProfilePosts_LimitTooLarge(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetPublicProfilePosts(context.Background(), "user", &PostsOptions{Limit: 101})
+	if err == nil {
+		t.Fatal("expected error for limit > 100")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestGetPublicProfilePosts_404(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found"}}`))
+	_, err := client.GetPublicProfilePosts(context.Background(), "nonexistent", nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetPublicProfilePosts_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.GetPublicProfilePosts(context.Background(), "user", nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestGetUserReplies_Success(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{
+		"data": [{"id":"r1","text":"Reply 1","is_reply":true},{"id":"r2","text":"Reply 2","is_reply":true}],
+		"paging": {}
+	}`))
+
+	resp, err := client.GetUserReplies(context.Background(), ConvertToUserID("12345"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 replies, got %d", len(resp.Data))
+	}
+}
+
+func TestGetUserReplies_InvalidUserID(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetUserReplies(context.Background(), UserID(""), nil)
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestGetUserReplies_WithOptions(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("limit") != "5" {
+			t.Errorf("expected limit=5, got %s", q.Get("limit"))
+		}
+		if q.Get("before") != "b_cursor" {
+			t.Errorf("expected before=b_cursor, got %s", q.Get("before"))
+		}
+		if q.Get("after") != "a_cursor" {
+			t.Errorf("expected after=a_cursor, got %s", q.Get("after"))
+		}
+		if q.Get("since") != "100" {
+			t.Errorf("expected since=100, got %s", q.Get("since"))
+		}
+		if q.Get("until") != "200" {
+			t.Errorf("expected until=200, got %s", q.Get("until"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.GetUserReplies(context.Background(), ConvertToUserID("12345"), &PostsOptions{
+		Limit:  5,
+		Before: "b_cursor",
+		After:  "a_cursor",
+		Since:  100,
+		Until:  200,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetUserReplies_LimitTooLarge(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	_, err := client.GetUserReplies(context.Background(), ConvertToUserID("12345"), &PostsOptions{Limit: 101})
+	if err == nil {
+		t.Fatal("expected error for limit > 100")
+	}
+}
+
+func TestGetUserReplies_404(t *testing.T) {
+	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found"}}`))
+	_, err := client.GetUserReplies(context.Background(), ConvertToUserID("99999"), nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGetUserReplies_403(t *testing.T) {
+	client := testClient(t, jsonHandler(403, `{"error":{"message":"forbidden"}}`))
+	_, err := client.GetUserReplies(context.Background(), ConvertToUserID("99999"), nil)
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+}
+
+func TestGetUserReplies_500(t *testing.T) {
+	client := testClient(t, jsonHandler(500, `{"error":{"message":"server error"}}`))
+	_, err := client.GetUserReplies(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestGetUser_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetUser(context.Background(), ConvertToUserID("12345"))
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestGetUser_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json at all`))
+	_, err := client.GetUser(context.Background(), ConvertToUserID("12345"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestGetMe_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetMe(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestLookupPublicProfile_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.LookupPublicProfile(context.Background(), "testuser")
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestLookupPublicProfile_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+	_, err := client.LookupPublicProfile(context.Background(), "testuser")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestGetUserFields_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetUserFields(context.Background(), ConvertToUserID("12345"), []string{"id"})
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestGetUserFields_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+	_, err := client.GetUserFields(context.Background(), ConvertToUserID("12345"), []string{"id"})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestGetPublicProfilePosts_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetPublicProfilePosts(context.Background(), "testuser", nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestGetPublicProfilePosts_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+	_, err := client.GetPublicProfilePosts(context.Background(), "testuser", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestGetUserReplies_NoAuth(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `{}`))
+	_, err := client.GetUserReplies(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated client")
+	}
+}
+
+func TestGetUserReplies_InvalidJSON(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `not json`))
+	_, err := client.GetUserReplies(context.Background(), ConvertToUserID("12345"), nil)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
 	}
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,497 @@
+package threads
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidatePostContent(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("nil content returns error", func(t *testing.T) {
+		err := v.ValidatePostContent(nil, 0)
+		if err == nil {
+			t.Fatal("Expected error for nil content")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("non-nil content returns nil", func(t *testing.T) {
+		err := v.ValidatePostContent("some content", 0)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+}
+
+func TestValidateTextAttachment(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("nil is valid", func(t *testing.T) {
+		err := v.ValidateTextAttachment(nil)
+		if err != nil {
+			t.Errorf("Expected no error for nil, got: %v", err)
+		}
+	})
+
+	t.Run("empty plaintext returns error", func(t *testing.T) {
+		err := v.ValidateTextAttachment(&TextAttachment{Plaintext: ""})
+		if err == nil {
+			t.Fatal("Expected error for empty plaintext")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("valid plaintext", func(t *testing.T) {
+		err := v.ValidateTextAttachment(&TextAttachment{Plaintext: "Hello world"})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("plaintext too long", func(t *testing.T) {
+		longText := make([]byte, MaxTextAttachmentLength+1)
+		for i := range longText {
+			longText[i] = 'a'
+		}
+		err := v.ValidateTextAttachment(&TextAttachment{Plaintext: string(longText)})
+		if err == nil {
+			t.Fatal("Expected error for plaintext too long")
+		}
+	})
+
+	t.Run("valid with styling info", func(t *testing.T) {
+		err := v.ValidateTextAttachment(&TextAttachment{
+			Plaintext: "Hello world styled",
+			TextWithStylingInfo: []TextStylingInfo{
+				{Offset: 0, Length: 5, StylingInfo: []string{"bold"}},
+				{Offset: 6, Length: 5, StylingInfo: []string{"italic"}},
+			},
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("overlapping styling ranges returns error", func(t *testing.T) {
+		err := v.ValidateTextAttachment(&TextAttachment{
+			Plaintext: "Hello world styled",
+			TextWithStylingInfo: []TextStylingInfo{
+				{Offset: 0, Length: 8, StylingInfo: []string{"bold"}},
+				{Offset: 5, Length: 5, StylingInfo: []string{"italic"}},
+			},
+		})
+		if err == nil {
+			t.Fatal("Expected error for overlapping styling ranges")
+		}
+	})
+}
+
+func TestValidateTextStylingRanges(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("no overlap", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 5},
+			{Offset: 5, Length: 5},
+			{Offset: 10, Length: 5},
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("overlapping ranges", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 10},
+			{Offset: 5, Length: 10},
+		})
+		if err == nil {
+			t.Fatal("Expected error for overlapping ranges")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{})
+		if err != nil {
+			t.Errorf("Expected no error for empty slice, got: %v", err)
+		}
+	})
+
+	t.Run("single range", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 5},
+		})
+		if err != nil {
+			t.Errorf("Expected no error for single range, got: %v", err)
+		}
+	})
+}
+
+func TestValidateTextEntities(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("empty slice is valid", func(t *testing.T) {
+		err := v.ValidateTextEntities(nil)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("valid spoiler entity", func(t *testing.T) {
+		err := v.ValidateTextEntities([]TextEntity{
+			{EntityType: "SPOILER", Offset: 0, Length: 5},
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("valid lowercase spoiler entity", func(t *testing.T) {
+		err := v.ValidateTextEntities([]TextEntity{
+			{EntityType: "spoiler", Offset: 0, Length: 5},
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("too many entities", func(t *testing.T) {
+		entities := make([]TextEntity, MaxTextEntities+1)
+		for i := range entities {
+			entities[i] = TextEntity{EntityType: "SPOILER", Offset: i * 10, Length: 5}
+		}
+		err := v.ValidateTextEntities(entities)
+		if err == nil {
+			t.Fatal("Expected error for too many entities")
+		}
+	})
+
+	t.Run("missing entity type", func(t *testing.T) {
+		err := v.ValidateTextEntities([]TextEntity{
+			{EntityType: "", Offset: 0, Length: 5},
+		})
+		if err == nil {
+			t.Fatal("Expected error for missing entity type")
+		}
+	})
+
+	t.Run("invalid entity type", func(t *testing.T) {
+		err := v.ValidateTextEntities([]TextEntity{
+			{EntityType: "BOLD", Offset: 0, Length: 5},
+		})
+		if err == nil {
+			t.Fatal("Expected error for invalid entity type")
+		}
+	})
+
+	t.Run("negative offset", func(t *testing.T) {
+		err := v.ValidateTextEntities([]TextEntity{
+			{EntityType: "SPOILER", Offset: -1, Length: 5},
+		})
+		if err == nil {
+			t.Fatal("Expected error for negative offset")
+		}
+	})
+
+	t.Run("zero length", func(t *testing.T) {
+		err := v.ValidateTextEntities([]TextEntity{
+			{EntityType: "SPOILER", Offset: 0, Length: 0},
+		})
+		if err == nil {
+			t.Fatal("Expected error for zero length")
+		}
+	})
+
+	t.Run("negative length", func(t *testing.T) {
+		err := v.ValidateTextEntities([]TextEntity{
+			{EntityType: "SPOILER", Offset: 0, Length: -1},
+		})
+		if err == nil {
+			t.Fatal("Expected error for negative length")
+		}
+	})
+}
+
+func TestValidateCarouselChildren(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("valid count", func(t *testing.T) {
+		err := v.ValidateCarouselChildren(5)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("minimum valid count", func(t *testing.T) {
+		err := v.ValidateCarouselChildren(MinCarouselItems)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("maximum valid count", func(t *testing.T) {
+		err := v.ValidateCarouselChildren(MaxCarouselItems)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("too few children", func(t *testing.T) {
+		err := v.ValidateCarouselChildren(1)
+		if err == nil {
+			t.Fatal("Expected error for too few children")
+		}
+	})
+
+	t.Run("too many children", func(t *testing.T) {
+		err := v.ValidateCarouselChildren(MaxCarouselItems + 1)
+		if err == nil {
+			t.Fatal("Expected error for too many children")
+		}
+	})
+}
+
+func TestValidateSearchOptions(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("nil is valid", func(t *testing.T) {
+		err := v.ValidateSearchOptions(nil)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("valid options", func(t *testing.T) {
+		err := v.ValidateSearchOptions(&SearchOptions{
+			Limit: 25,
+			Since: MinSearchTimestamp,
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("limit too large", func(t *testing.T) {
+		err := v.ValidateSearchOptions(&SearchOptions{
+			Limit: MaxPostsPerRequest + 1,
+		})
+		if err == nil {
+			t.Fatal("Expected error for limit too large")
+		}
+	})
+
+	t.Run("since too old", func(t *testing.T) {
+		err := v.ValidateSearchOptions(&SearchOptions{
+			Since: 100, // way before MinSearchTimestamp
+		})
+		if err == nil {
+			t.Fatal("Expected error for since too old")
+		}
+	})
+
+	t.Run("since zero is valid", func(t *testing.T) {
+		err := v.ValidateSearchOptions(&SearchOptions{
+			Since: 0,
+		})
+		if err != nil {
+			t.Errorf("Expected no error for since=0, got: %v", err)
+		}
+	})
+}
+
+func TestConfigValidatorValidateRequiredFields(t *testing.T) {
+	cv := NewConfigValidator()
+
+	t.Run("missing client secret", func(t *testing.T) {
+		cfg := &Config{
+			ClientID:    "id",
+			RedirectURI: "https://example.com/callback",
+			Scopes:      []string{"threads_basic"},
+			HTTPTimeout: 30 * time.Second,
+			BaseURL:     "https://graph.threads.net",
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for missing client secret")
+		}
+	})
+
+	t.Run("missing redirect URI", func(t *testing.T) {
+		cfg := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for missing redirect URI")
+		}
+	})
+}
+
+func TestConfigValidatorValidateHTTPSettings(t *testing.T) {
+	cv := NewConfigValidator()
+
+	t.Run("zero timeout", func(t *testing.T) {
+		cfg := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  0,
+			BaseURL:      "https://graph.threads.net",
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for zero HTTPTimeout")
+		}
+	})
+
+	t.Run("empty base URL", func(t *testing.T) {
+		cfg := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "",
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for empty BaseURL")
+		}
+	})
+
+	t.Run("invalid base URL scheme", func(t *testing.T) {
+		cfg := &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "ftp://example.com",
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for non-HTTP base URL")
+		}
+	})
+}
+
+func TestConfigValidatorValidateRetryConfig(t *testing.T) {
+	cv := NewConfigValidator()
+
+	baseConfig := func() *Config {
+		return &Config{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/callback",
+			Scopes:       []string{"threads_basic"},
+			HTTPTimeout:  30 * time.Second,
+			BaseURL:      "https://graph.threads.net",
+		}
+	}
+
+	t.Run("nil retry config is valid", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.RetryConfig = nil
+		err := cv.Validate(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("negative max retries", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.RetryConfig = &RetryConfig{
+			MaxRetries:    -1,
+			InitialDelay:  time.Second,
+			MaxDelay:      30 * time.Second,
+			BackoffFactor: 2.0,
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for negative MaxRetries")
+		}
+	})
+
+	t.Run("zero initial delay", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.RetryConfig = &RetryConfig{
+			MaxRetries:    3,
+			InitialDelay:  0,
+			MaxDelay:      30 * time.Second,
+			BackoffFactor: 2.0,
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for zero InitialDelay")
+		}
+	})
+
+	t.Run("zero max delay", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.RetryConfig = &RetryConfig{
+			MaxRetries:    3,
+			InitialDelay:  time.Second,
+			MaxDelay:      0,
+			BackoffFactor: 2.0,
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for zero MaxDelay")
+		}
+	})
+
+	t.Run("zero backoff factor", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.RetryConfig = &RetryConfig{
+			MaxRetries:    3,
+			InitialDelay:  time.Second,
+			MaxDelay:      30 * time.Second,
+			BackoffFactor: 0,
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for zero BackoffFactor")
+		}
+	})
+
+	t.Run("initial delay greater than max delay", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.RetryConfig = &RetryConfig{
+			MaxRetries:    3,
+			InitialDelay:  time.Minute,
+			MaxDelay:      time.Second,
+			BackoffFactor: 2.0,
+		}
+		err := cv.Validate(cfg)
+		if err == nil {
+			t.Fatal("Expected error for InitialDelay > MaxDelay")
+		}
+	})
+
+	t.Run("valid retry config", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.RetryConfig = &RetryConfig{
+			MaxRetries:    3,
+			InitialDelay:  time.Second,
+			MaxDelay:      30 * time.Second,
+			BackoffFactor: 2.0,
+		}
+		err := cv.Validate(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Prepares the project for listing on [awesome-go](https://github.com/avelino/awesome-go) by meeting all quality requirements:

- **Test coverage: 51.3% → 93.6%** (requirement: ≥80%)
- **Codecov integration** added to CI for coverage reporting (required for PR submission)
- **CI status badge** and **Codecov badge** added to README
- **Test helpers refactored** to reduce boilerplate and use idiomatic Go patterns

### Changes

**CI/Badges (1 file):**
- `.github/workflows/ci.yml` — Codecov upload step
- `README.md` — CI and Codecov badges

**New test files (5):**
- `errors_test.go`, `types_test.go`, `validation_test.go`, `posts_replies_test.go`, `posts_validation_test.go`

**Expanded test files (12):**
- `auth_test.go`, `client_test.go`, `http_client_test.go`, `insights_test.go`, `location_test.go`, `pagination_test.go`, `posts_create_test.go`, `posts_delete_test.go`, `posts_read_test.go`, `ratelimit_test.go`, `replies_test.go`, `search_test.go`, `users_test.go`

**Refactored test helpers (2):**
- `test_helpers_test.go` — removed unused param, added `newBareClient` helper
- `client_test.go` — replaced `getenvSafe`/`setenvSafe` with `t.Setenv`, removed dead code

## Test plan

- [x] All tests pass with `-race` flag
- [x] `go vet ./...` clean
- [x] `gofmt -s` clean
- [x] Coverage verified at 93.6% with both `-short` and full runs
- [x] Gist badge extraction command produces correct output
- [x] Set up `CODECOV_TOKEN` secret in GitHub repo settings after merge