### PR TITLE
feat: API conformance audit — align client with official Threads API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ post, err := client.GetPost(ctx, threads.PostID("123"))
 posts, err := client.GetUserPosts(ctx, threads.UserID("456"), &threads.PaginationOptions{Limit: 25})
 
 // Delete post
-err = client.DeletePost(ctx, threads.PostID("123"))
+deletedID, err := client.DeletePost(ctx, threads.PostID("123"))
 ```
 
 ### Users & Profiles

--- a/README.md
+++ b/README.md
@@ -69,12 +69,11 @@ err = client.GetLongLivedToken(ctx) // Convert to long-lived token
 
 ### App Access Tokens
 
-For server-to-server use cases that don't require user authorization:
+For APIs that require app-level auth instead of user tokens (e.g., oEmbed):
 
 ```go
-// Full API call
+// Full API call (server-side only — exposes app secret)
 tokenResp, err := client.GetAppAccessToken(ctx)
-fmt.Println(tokenResp.AccessToken)
 
 // Or use the shorthand format (no API call needed)
 shorthand := client.GetAppAccessTokenShorthand() // "TH|<APP_ID>|<APP_SECRET>"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ err = client.ExchangeCodeForToken(ctx, "auth-code-from-callback")
 err = client.GetLongLivedToken(ctx) // Convert to long-lived token
 ```
 
+### App Access Tokens
+
+For server-to-server use cases that don't require user authorization:
+
+```go
+// Full API call
+tokenResp, err := client.GetAppAccessToken(ctx)
+fmt.Println(tokenResp.AccessToken)
+
+// Or use the shorthand format (no API call needed)
+shorthand := client.GetAppAccessTokenShorthand() // "TH|<APP_ID>|<APP_SECRET>"
+```
+
 ### Environment Variables
 
 ```bash

--- a/auth.go
+++ b/auth.go
@@ -480,6 +480,10 @@ func (c *Client) DebugToken(ctx context.Context, inputToken string) (*DebugToken
 // Unlike user access tokens, the returned token is NOT stored in the client — app tokens
 // serve a different purpose and should be managed separately by the caller.
 // This requires ClientID and ClientSecret to be set in the client configuration.
+//
+// NOTE: The Threads API requires GET for this endpoint (not the POST + body
+// approach specified in RFC 6749 §4.4). As a result, client_secret appears in
+// the request URL. Only call this from a server-side environment.
 func (c *Client) GetAppAccessToken(ctx context.Context) (*AppAccessTokenResponse, error) {
 	params := url.Values{
 		"client_id":     {c.config.ClientID},
@@ -512,7 +516,11 @@ func (c *Client) GetAppAccessToken(ctx context.Context) (*AppAccessTokenResponse
 // GetAppAccessTokenShorthand returns the shorthand app token in the form TH|<APP_ID>|<APP_SECRET>.
 // This can be used directly as an access token for certain API operations without making an API call.
 // See the Threads API documentation for which endpoints accept this format.
+// Returns an empty string if ClientID or ClientSecret are not configured.
 func (c *Client) GetAppAccessTokenShorthand() string {
+	if c.config.ClientID == "" || c.config.ClientSecret == "" {
+		return ""
+	}
 	return "TH|" + c.config.ClientID + "|" + c.config.ClientSecret
 }
 

--- a/auth.go
+++ b/auth.go
@@ -31,6 +31,13 @@ type LongLivedTokenResponse struct {
 	ExpiresIn   int64  `json:"expires_in"`
 }
 
+// AppAccessTokenResponse represents the response from the client_credentials token endpoint.
+// Unlike user token responses, app access tokens do not include expires_in or user_id fields.
+type AppAccessTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
 // generateState generates a random state parameter for OAuth security
 func generateState() (string, error) {
 	b := make([]byte, 32)
@@ -467,6 +474,46 @@ func (c *Client) DebugToken(ctx context.Context, inputToken string) (*DebugToken
 	}
 
 	return &debugResp, nil
+}
+
+// GetAppAccessToken generates an app access token via the client_credentials OAuth flow.
+// Unlike user access tokens, the returned token is NOT stored in the client — app tokens
+// serve a different purpose and should be managed separately by the caller.
+// This requires ClientID and ClientSecret to be set in the client configuration.
+func (c *Client) GetAppAccessToken(ctx context.Context) (*AppAccessTokenResponse, error) {
+	params := url.Values{
+		"client_id":     {c.config.ClientID},
+		"client_secret": {c.config.ClientSecret},
+		"grant_type":    {"client_credentials"},
+	}
+
+	resp, err := c.httpClient.GET("/oauth/access_token", params, "")
+	if err != nil {
+		return nil, NewNetworkError(0, "Failed to get app access token", err.Error(), true)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleTokenError(resp.StatusCode, resp.Body)
+	}
+
+	var tokenResp AppAccessTokenResponse
+	if err := json.Unmarshal(resp.Body, &tokenResp); err != nil {
+		return nil, NewAPIError(resp.StatusCode, "Failed to parse app access token response", err.Error(), "")
+	}
+
+	if c.config.Logger != nil {
+		c.config.Logger.Info("Successfully obtained app access token",
+			"token_type", tokenResp.TokenType)
+	}
+
+	return &tokenResp, nil
+}
+
+// GetAppAccessTokenShorthand returns the shorthand app token in the form TH|<APP_ID>|<APP_SECRET>.
+// This can be used directly as an access token for certain API operations without making an API call.
+// See the Threads API documentation for which endpoints accept this format.
+func (c *Client) GetAppAccessTokenShorthand() string {
+	return "TH|" + c.config.ClientID + "|" + c.config.ClientSecret
 }
 
 // SetTokenFromDebugInfo creates and sets token info from debug token response.

--- a/auth_test.go
+++ b/auth_test.go
@@ -788,6 +788,7 @@ func TestGetAppAccessTokenShorthand_Format(t *testing.T) {
 	}
 }
 
+
 func TestTokenExpiration(t *testing.T) {
 	config := &Config{
 		ClientID:     "test-id",

--- a/auth_test.go
+++ b/auth_test.go
@@ -656,6 +656,138 @@ func TestSetTokenFromDebugInfo_WithLogger(t *testing.T) {
 	}
 }
 
+func TestGetAppAccessToken_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Path != "/oauth/access_token" {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		if q.Get("grant_type") != "client_credentials" {
+			w.WriteHeader(400)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"access_token":"TH|test-client-id|some_token","token_type":"bearer"}`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	config := &Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	config.BaseURL = server.URL
+
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.GetAppAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "TH|test-client-id|some_token" {
+		t.Errorf("expected TH|test-client-id|some_token, got %s", resp.AccessToken)
+	}
+	if resp.TokenType != "bearer" {
+		t.Errorf("expected bearer, got %s", resp.TokenType)
+	}
+	// App token must NOT be stored in client
+	if client.GetAccessToken() != "" {
+		t.Error("expected client access token to remain empty after GetAppAccessToken")
+	}
+}
+
+func TestGetAppAccessToken_ServerError(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(401, `{"error":{"message":"invalid credentials","type":"OAuthException","code":100}}`))
+	_, err := client.GetAppAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+
+func TestGetAppAccessToken_ParseError(t *testing.T) {
+	client := testClientNoAuth(t, jsonHandler(200, `not valid json`))
+	_, err := client.GetAppAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestGetAppAccessToken_WithLogger(t *testing.T) {
+	handler := jsonHandler(200, `{"access_token":"TH|id|tok","token_type":"bearer"}`)
+	config := testClientConfig(t, handler)
+	config.Logger = &noopLogger{}
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.GetAppAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "TH|id|tok" {
+		t.Errorf("expected TH|id|tok, got %s", resp.AccessToken)
+	}
+}
+
+func TestGetAppAccessTokenShorthand(t *testing.T) {
+	config := &Config{
+		ClientID:     "my-app-123",
+		ClientSecret: "my-secret-abc",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shorthand := client.GetAppAccessTokenShorthand()
+	expected := "TH|my-app-123|my-secret-abc"
+	if shorthand != expected {
+		t.Errorf("expected %q, got %q", expected, shorthand)
+	}
+}
+
+func TestGetAppAccessTokenShorthand_Format(t *testing.T) {
+	config := &Config{
+		ClientID:     "appid",
+		ClientSecret: "appsecret",
+		RedirectURI:  "https://example.com/callback",
+	}
+	config.SetDefaults()
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shorthand := client.GetAppAccessTokenShorthand()
+	if !strings.HasPrefix(shorthand, "TH|") {
+		t.Errorf("expected shorthand to start with TH|, got %q", shorthand)
+	}
+	parts := strings.Split(shorthand, "|")
+	if len(parts) != 3 {
+		t.Errorf("expected 3 pipe-separated parts, got %d: %q", len(parts), shorthand)
+	}
+	if parts[1] != "appid" {
+		t.Errorf("expected app ID appid in shorthand, got %q", parts[1])
+	}
+	if parts[2] != "appsecret" {
+		t.Errorf("expected app secret appsecret in shorthand, got %q", parts[2])
+	}
+}
+
 func TestTokenExpiration(t *testing.T) {
 	config := &Config{
 		ClientID:     "test-id",

--- a/auth_test.go
+++ b/auth_test.go
@@ -788,7 +788,6 @@ func TestGetAppAccessTokenShorthand_Format(t *testing.T) {
 	}
 }
 
-
 func TestTokenExpiration(t *testing.T) {
 	config := &Config{
 		ClientID:     "test-id",

--- a/constants.go
+++ b/constants.go
@@ -37,7 +37,7 @@ const (
 	MinSearchTimestamp = 1688540400 // Minimum timestamp for search queries (July 5, 2023)
 
 	// Library version
-	Version = "1.1.0"
+	Version = "1.8.0"
 
 	// HTTP client defaults
 	DefaultHTTPTimeout = 30 * time.Second // Default HTTP request timeout

--- a/constants.go
+++ b/constants.go
@@ -25,6 +25,14 @@ const (
 	// Reply processing
 	ReplyPublishDelay = 10 * time.Second // Recommended delay before publishing reply
 
+	// Poll limits
+	MinPollOptions      = 2  // Minimum poll options (A and B required)
+	MaxPollOptions      = 4  // Maximum poll options
+	MaxPollOptionLength = 25 // Maximum characters per poll option
+
+	// Alt text limits
+	MaxAltTextLength = 1000 // Maximum characters for alt text
+
 	// Search constraints
 	MinSearchTimestamp = 1688540400 // Minimum timestamp for search queries (July 5, 2023)
 

--- a/constants.go
+++ b/constants.go
@@ -44,7 +44,7 @@ const (
 // Field Sets for API requests
 const (
 	// Post fields
-	PostExtendedFields = "id,media_product_type,media_type,media_url,permalink,owner,username,text,timestamp,shortcode,thumbnail_url,children,is_quote_post,alt_text,link_attachment_url,has_replies,reply_audience,quoted_post,reposted_post,gif_url,is_verified,profile_picture_url"
+	PostExtendedFields = "id,media_product_type,media_type,media_url,permalink,owner,username,text,timestamp,shortcode,thumbnail_url,children,is_quote_post,alt_text,link_attachment_url,has_replies,reply_audience,quoted_post,reposted_post,gif_url,is_verified,profile_picture_url,poll_attachment,topic_tag,is_spoiler_media,text_entities,text_attachment,location_id,location,allowlisted_country_codes,ghost_post_status,ghost_post_expiration_timestamp,is_reply,root_post,replied_to,is_reply_owned_by_me,hide_status,reply_approval_status"
 
 	// Ghost Post fields
 	GhostPostFields = "id,media_product_type,media_type,media_url,permalink,owner,username,text,timestamp,shortcode,thumbnail_url,ghost_post_status,ghost_post_expiration_timestamp"
@@ -62,7 +62,7 @@ const (
 	LocationFields = "id,address,name,city,country,latitude,longitude,postal_code"
 
 	// Publishing limit fields
-	PublishingLimitFields = "quota_usage,config,reply_quota_usage,reply_config,delete_quota_usage,delete_config,location_search_quota_usage,location_search_config"
+	PublishingLimitFields = "quota_usage,config,reply_quota_usage,reply_config,delete_quota_usage,delete_config,location_search_quota_usage,location_search_config,search_quota_usage,search_config"
 )
 
 // Container Status values
@@ -84,6 +84,26 @@ const (
 	MediaTypeImage    = "IMAGE"
 	MediaTypeVideo    = "VIDEO"
 	MediaTypeCarousel = "CAROUSEL"
+
+	// Response media types (returned by the API when retrieving posts)
+	MediaTypeResponseText     = "TEXT_POST"
+	MediaTypeResponseCarousel = "CAROUSEL_ALBUM"
+	MediaTypeAudio            = "AUDIO"
+	MediaTypeRepostFacade     = "REPOST_FACADE"
+)
+
+// Container error messages returned by the API
+const (
+	ContainerErrFailedDownloadingVideo    = "FAILED_DOWNLOADING_VIDEO"
+	ContainerErrFailedProcessingAudio     = "FAILED_PROCESSING_AUDIO"
+	ContainerErrFailedProcessingVideo     = "FAILED_PROCESSING_VIDEO"
+	ContainerErrInvalidAspectRatio        = "INVALID_ASPEC_RATIO" // Note: API has typo "ASPEC"
+	ContainerErrInvalidBitRate            = "INVALID_BIT_RATE"
+	ContainerErrInvalidDuration           = "INVALID_DURATION"
+	ContainerErrInvalidFrameRate          = "INVALID_FRAME_RATE"
+	ContainerErrInvalidAudioChannels      = "INVALID_AUDIO_CHANNELS"
+	ContainerErrInvalidAudioChannelLayout = "INVALID_AUDIO_CHANNEL_LAYOUT"
+	ContainerErrUnknown                   = "UNKNOWN"
 )
 
 // Error messages

--- a/constants.go
+++ b/constants.go
@@ -128,4 +128,12 @@ const (
 	// This error occurs during media container creation (POST /{threads-user-id}/threads).
 	// Reduce the number of unique links to 5 or fewer to resolve.
 	ErrCodeLinkLimitExceeded = "THREADS_API__LINK_LIMIT_EXCEEDED"
+
+	// ErrCodeFeatureNotAvailable is returned when a feature is not available for the user.
+	// For example, geo-gating requires feature approval before it can be used.
+	ErrCodeFeatureNotAvailable = "THREADS_API__FEATURE_NOT_AVAILABLE"
+
+	// ErrCodeGeoGatingInvalidCountryCodes is returned when invalid country codes
+	// are provided for geo-gated posts.
+	ErrCodeGeoGatingInvalidCountryCodes = "THREADS_API__GEO_GATING_INVALID_COUNTRY_CODES"
 )

--- a/container_builder.go
+++ b/container_builder.go
@@ -217,9 +217,9 @@ func (b *ContainerBuilder) SetGIFAttachment(gifAttachment *GIFAttachment) *Conta
 }
 
 // SetIsGhostPost marks the post as a ghost post (text-only, expires in 24h, no replies allowed).
-// Ghost posts are only supported for TEXT media type. If the builder's media_type is set to
-// a non-TEXT value, this call is silently ignored.
-// Note: Call SetMediaType before SetIsGhostPost to ensure the media type guard is effective.
+// Ghost posts are only supported for TEXT media type. If the builder's media_type is already set
+// to a non-TEXT value this call is silently ignored; if a non-TEXT type is set after this call,
+// SetMediaType will automatically clear the flag.
 func (b *ContainerBuilder) SetIsGhostPost(isGhostPost bool) *ContainerBuilder {
 	if isGhostPost {
 		// Ghost posts are only allowed for TEXT media type

--- a/container_builder.go
+++ b/container_builder.go
@@ -214,6 +214,7 @@ func (b *ContainerBuilder) SetGIFAttachment(gifAttachment *GIFAttachment) *Conta
 // SetIsGhostPost marks the post as a ghost post (text-only, expires in 24h, no replies allowed).
 // Ghost posts are only supported for TEXT media type. If the builder's media_type is set to
 // a non-TEXT value, this call is silently ignored.
+// Note: Call SetMediaType before SetIsGhostPost to ensure the media type guard is effective.
 func (b *ContainerBuilder) SetIsGhostPost(isGhostPost bool) *ContainerBuilder {
 	if isGhostPost {
 		// Ghost posts are only allowed for TEXT media type

--- a/container_builder.go
+++ b/container_builder.go
@@ -229,6 +229,8 @@ func (b *ContainerBuilder) SetIsGhostPost(isGhostPost bool) *ContainerBuilder {
 			return b
 		}
 		b.params.Set("is_ghost_post", "true")
+	} else {
+		b.params.Del("is_ghost_post")
 	}
 	return b
 }

--- a/container_builder.go
+++ b/container_builder.go
@@ -18,9 +18,14 @@ func NewContainerBuilder() *ContainerBuilder {
 	}
 }
 
-// SetMediaType sets the media type
+// SetMediaType sets the media type.
+// If a non-TEXT type is set, any previously set is_ghost_post flag is cleared
+// since ghost posts are only supported for TEXT.
 func (b *ContainerBuilder) SetMediaType(mediaType string) *ContainerBuilder {
 	b.params.Set("media_type", mediaType)
+	if mediaType != "" && mediaType != MediaTypeText {
+		b.params.Del("is_ghost_post")
+	}
 	return b
 }
 

--- a/container_builder.go
+++ b/container_builder.go
@@ -211,9 +211,17 @@ func (b *ContainerBuilder) SetGIFAttachment(gifAttachment *GIFAttachment) *Conta
 	return b
 }
 
-// SetIsGhostPost marks the post as a ghost post (text-only, expires in 24h, no replies allowed)
+// SetIsGhostPost marks the post as a ghost post (text-only, expires in 24h, no replies allowed).
+// Ghost posts are only supported for TEXT media type. If the builder's media_type is set to
+// a non-TEXT value, this call is silently ignored.
 func (b *ContainerBuilder) SetIsGhostPost(isGhostPost bool) *ContainerBuilder {
 	if isGhostPost {
+		// Ghost posts are only allowed for TEXT media type
+		mediaType := b.params.Get("media_type")
+		if mediaType != "" && mediaType != MediaTypeText {
+			// Silently ignore - ghost post flag is not applicable to non-text posts
+			return b
+		}
 		b.params.Set("is_ghost_post", "true")
 	}
 	return b

--- a/container_builder_test.go
+++ b/container_builder_test.go
@@ -1,0 +1,69 @@
+package threads
+
+import "testing"
+
+func TestContainerBuilder_SetIsGhostPost_TextMediaType(t *testing.T) {
+	b := NewContainerBuilder().
+		SetMediaType(MediaTypeText).
+		SetIsGhostPost(true)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "true" {
+		t.Error("expected is_ghost_post to be set for TEXT media type")
+	}
+}
+
+func TestContainerBuilder_SetIsGhostPost_ImageMediaType_Ignored(t *testing.T) {
+	b := NewContainerBuilder().
+		SetMediaType(MediaTypeImage).
+		SetIsGhostPost(true)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "" {
+		t.Error("expected is_ghost_post to be ignored for IMAGE media type")
+	}
+}
+
+func TestContainerBuilder_SetIsGhostPost_VideoMediaType_Ignored(t *testing.T) {
+	b := NewContainerBuilder().
+		SetMediaType(MediaTypeVideo).
+		SetIsGhostPost(true)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "" {
+		t.Error("expected is_ghost_post to be ignored for VIDEO media type")
+	}
+}
+
+func TestContainerBuilder_SetIsGhostPost_CarouselMediaType_Ignored(t *testing.T) {
+	b := NewContainerBuilder().
+		SetMediaType(MediaTypeCarousel).
+		SetIsGhostPost(true)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "" {
+		t.Error("expected is_ghost_post to be ignored for CAROUSEL media type")
+	}
+}
+
+func TestContainerBuilder_SetIsGhostPost_NoMediaType_Allowed(t *testing.T) {
+	// When media_type is not yet set, ghost post flag should be allowed
+	b := NewContainerBuilder().
+		SetIsGhostPost(true)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "true" {
+		t.Error("expected is_ghost_post to be set when no media_type is specified")
+	}
+}
+
+func TestContainerBuilder_SetIsGhostPost_False_NotSet(t *testing.T) {
+	b := NewContainerBuilder().
+		SetMediaType(MediaTypeText).
+		SetIsGhostPost(false)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "" {
+		t.Error("expected is_ghost_post to not be set when isGhostPost=false")
+	}
+}

--- a/container_builder_test.go
+++ b/container_builder_test.go
@@ -46,14 +46,27 @@ func TestContainerBuilder_SetIsGhostPost_CarouselMediaType_Ignored(t *testing.T)
 	}
 }
 
-func TestContainerBuilder_SetIsGhostPost_NoMediaType_Allowed(t *testing.T) {
-	// When media_type is not yet set, ghost post flag should be allowed
+func TestContainerBuilder_SetIsGhostPost_NoMediaType_ThenText(t *testing.T) {
+	// Ghost post set before media type; TEXT should preserve it
 	b := NewContainerBuilder().
-		SetIsGhostPost(true)
+		SetIsGhostPost(true).
+		SetMediaType(MediaTypeText)
 
 	params := b.Build()
 	if params.Get("is_ghost_post") != "true" {
-		t.Error("expected is_ghost_post to be set when no media_type is specified")
+		t.Error("expected is_ghost_post to be preserved when media_type is set to TEXT after")
+	}
+}
+
+func TestContainerBuilder_SetIsGhostPost_NoMediaType_ThenImage(t *testing.T) {
+	// Ghost post set before media type; IMAGE should clear it
+	b := NewContainerBuilder().
+		SetIsGhostPost(true).
+		SetMediaType(MediaTypeImage)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "" {
+		t.Error("expected is_ghost_post to be cleared when media_type is set to IMAGE after")
 	}
 }
 

--- a/container_builder_test.go
+++ b/container_builder_test.go
@@ -70,6 +70,19 @@ func TestContainerBuilder_SetIsGhostPost_NoMediaType_ThenImage(t *testing.T) {
 	}
 }
 
+func TestContainerBuilder_SetIsGhostPost_ToggleTrueToFalse(t *testing.T) {
+	// Setting true then false should clear the flag
+	b := NewContainerBuilder().
+		SetMediaType(MediaTypeText).
+		SetIsGhostPost(true).
+		SetIsGhostPost(false)
+
+	params := b.Build()
+	if params.Get("is_ghost_post") != "" {
+		t.Error("expected is_ghost_post to be cleared after SetIsGhostPost(false)")
+	}
+}
+
 func TestContainerBuilder_SetIsGhostPost_False_NotSet(t *testing.T) {
 	b := NewContainerBuilder().
 		SetMediaType(MediaTypeText).

--- a/insights.go
+++ b/insights.go
@@ -13,7 +13,8 @@ import (
 type PostInsightMetric string
 
 const (
-	// PostInsightViews represents the number of times a post was viewed
+	// PostInsightViews represents the number of times a post was viewed.
+	// Note: This metric is noted as "in development" in the API documentation.
 	PostInsightViews PostInsightMetric = "views"
 	// PostInsightLikes represents the number of likes a post received
 	PostInsightLikes PostInsightMetric = "likes"
@@ -23,7 +24,8 @@ const (
 	PostInsightReposts PostInsightMetric = "reposts"
 	// PostInsightQuotes represents the number of times a post was quoted
 	PostInsightQuotes PostInsightMetric = "quotes"
-	// PostInsightShares represents the number of times a post was shared
+	// PostInsightShares represents the number of times a post was shared.
+	// Note: This metric is noted as "in development" in the API documentation.
 	PostInsightShares PostInsightMetric = "shares"
 )
 
@@ -31,7 +33,8 @@ const (
 type AccountInsightMetric string
 
 const (
-	// AccountInsightViews represents the total views across all account posts
+	// AccountInsightViews represents the total views across all account posts.
+	// Note: This metric is noted as "in development" in the API documentation.
 	AccountInsightViews AccountInsightMetric = "views"
 	// AccountInsightLikes represents the total likes across all account posts
 	AccountInsightLikes AccountInsightMetric = "likes"

--- a/interfaces.go
+++ b/interfaces.go
@@ -39,6 +39,12 @@ type Authenticator interface {
 
 	// GetTokenDebugInfo returns detailed token information
 	GetTokenDebugInfo() map[string]interface{}
+
+	// GetAppAccessToken generates an app access token via the client_credentials flow
+	GetAppAccessToken(ctx context.Context) (*AppAccessTokenResponse, error)
+
+	// GetAppAccessTokenShorthand returns the TH|APP_ID|APP_SECRET shorthand token
+	GetAppAccessTokenShorthand() string
 }
 
 // PostManager handles post creation, retrieval, and management

--- a/interfaces.go
+++ b/interfaces.go
@@ -94,7 +94,10 @@ type PostReader interface {
 	GetUserPostsWithOptions(ctx context.Context, userID UserID, opts *PostsOptions) (*PostsResponse, error)
 
 	// GetUserMentions retrieves posts where the user is mentioned
-	GetUserMentions(ctx context.Context, userID UserID, opts *PaginationOptions) (*PostsResponse, error)
+	GetUserMentions(ctx context.Context, userID UserID, opts *PostsOptions) (*PostsResponse, error)
+
+	// GetUserGhostPosts retrieves ghost posts from a specific user
+	GetUserGhostPosts(ctx context.Context, userID UserID, opts *PaginationOptions) (*PostsResponse, error)
 
 	// GetPublishingLimits retrieves current API quota usage
 	GetPublishingLimits(ctx context.Context) (*PublishingLimits, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -105,11 +105,11 @@ type PostReader interface {
 
 // PostDeleter handles post deletion operations
 type PostDeleter interface {
-	// DeletePost deletes a specific post
-	DeletePost(ctx context.Context, postID PostID) error
+	// DeletePost deletes a specific post and returns the deleted post ID
+	DeletePost(ctx context.Context, postID PostID) (string, error)
 
-	// DeletePostWithConfirmation deletes a post with confirmation
-	DeletePostWithConfirmation(ctx context.Context, postID PostID, confirmationCallback func(post *Post) bool) error
+	// DeletePostWithConfirmation deletes a post with confirmation and returns the deleted post ID
+	DeletePostWithConfirmation(ctx context.Context, postID PostID, confirmationCallback func(post *Post) bool) (string, error)
 }
 
 // PostValidator provides validation for post content

--- a/posts_delete.go
+++ b/posts_delete.go
@@ -7,6 +7,9 @@ import (
 )
 
 // DeletePost deletes a specific post by ID with proper validation and confirmation.
+// Returns the deleted post ID as reported by the API. If the API response cannot
+// be parsed, the returned ID will be an empty string; a non-nil error is only
+// returned when the HTTP request itself fails or the server returns a non-200 status.
 // Note: The API enforces a limit of 100 deletes per 24-hour window. Check
 // PublishingLimits.DeleteQuotaUsage via GetPublishingLimits to monitor usage.
 // The threads_delete permission scope is required for this endpoint.

--- a/posts_delete.go
+++ b/posts_delete.go
@@ -7,44 +7,45 @@ import (
 )
 
 // DeletePost deletes a specific post by ID with proper validation and confirmation
-func (c *Client) DeletePost(ctx context.Context, postID PostID) error {
+func (c *Client) DeletePost(ctx context.Context, postID PostID) (string, error) {
 	if !postID.Valid() {
-		return NewValidationError(400, ErrEmptyPostID, "Cannot delete post without ID", "post_id")
+		return "", NewValidationError(400, ErrEmptyPostID, "Cannot delete post without ID", "post_id")
 	}
 
 	// Ensure we have a valid token
 	if err := c.EnsureValidToken(ctx); err != nil {
-		return err
+		return "", err
 	}
 
 	// First, validate that the post exists and is owned by the authenticated user
 	if err := c.validatePostOwnership(ctx, postID); err != nil {
-		return err
+		return "", err
 	}
 
 	// Make API call to delete post
 	path := fmt.Sprintf("/%s", postID.String())
 	resp, err := c.httpClient.DELETE(path, c.getAccessTokenSafe())
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Handle specific error cases
 	if resp.StatusCode == 404 {
-		return NewValidationError(404, "Post not found", fmt.Sprintf("Post with ID %s does not exist or is not accessible", postID.String()), "post_id")
+		return "", NewValidationError(404, "Post not found", fmt.Sprintf("Post with ID %s does not exist or is not accessible", postID.String()), "post_id")
 	}
 
 	if resp.StatusCode == 403 {
-		return NewAuthenticationError(403, "Access denied", fmt.Sprintf("Cannot delete post %s - insufficient permissions or not the post owner", postID.String()))
+		return "", NewAuthenticationError(403, "Access denied", fmt.Sprintf("Cannot delete post %s - insufficient permissions or not the post owner", postID.String()))
 	}
 
 	if resp.StatusCode != 200 {
-		return c.handleAPIError(resp)
+		return "", c.handleAPIError(resp)
 	}
 
 	// Parse response to confirm deletion
 	var deleteResp struct {
-		Success bool `json:"success"`
+		Success   bool   `json:"success"`
+		DeletedID string `json:"deleted_id"`
 	}
 
 	if len(resp.Body) > 0 {
@@ -61,28 +62,28 @@ func (c *Client) DeletePost(ctx context.Context, postID PostID) error {
 		c.config.Logger.Info("Successfully deleted post", "post_id", postID.String())
 	}
 
-	return nil
+	return deleteResp.DeletedID, nil
 }
 
 // DeletePostWithConfirmation deletes a post with an additional confirmation step
-func (c *Client) DeletePostWithConfirmation(ctx context.Context, postID PostID, confirmationCallback func(post *Post) bool) error {
+func (c *Client) DeletePostWithConfirmation(ctx context.Context, postID PostID, confirmationCallback func(post *Post) bool) (string, error) {
 	if !postID.Valid() {
-		return NewValidationError(400, ErrEmptyPostID, "Cannot delete post without ID", "post_id")
+		return "", NewValidationError(400, ErrEmptyPostID, "Cannot delete post without ID", "post_id")
 	}
 
 	if confirmationCallback == nil {
-		return NewValidationError(400, "Confirmation callback is required", "Must provide confirmation callback", "confirmation_callback")
+		return "", NewValidationError(400, "Confirmation callback is required", "Must provide confirmation callback", "confirmation_callback")
 	}
 
 	// Get the post first to show details for confirmation
 	post, err := c.GetPost(ctx, postID)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Call confirmation callback
 	if !confirmationCallback(post) {
-		return NewValidationError(400, "Deletion cancelled", "User cancelled the deletion", "confirmation")
+		return "", NewValidationError(400, "Deletion cancelled", "User cancelled the deletion", "confirmation")
 	}
 
 	// Proceed with deletion

--- a/posts_delete.go
+++ b/posts_delete.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 )
 
-// DeletePost deletes a specific post by ID with proper validation and confirmation
+// DeletePost deletes a specific post by ID with proper validation and confirmation.
+// Note: The API enforces a limit of 100 deletes per 24-hour window. Check
+// PublishingLimits.DeleteQuotaUsage via GetPublishingLimits to monitor usage.
+// The threads_delete permission scope is required for this endpoint.
 func (c *Client) DeletePost(ctx context.Context, postID PostID) (string, error) {
 	if !postID.Valid() {
 		return "", NewValidationError(400, ErrEmptyPostID, "Cannot delete post without ID", "post_id")

--- a/posts_delete_test.go
+++ b/posts_delete_test.go
@@ -17,21 +17,24 @@ func TestDeletePost_Success(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{"success":true}`))
+		_, _ = w.Write([]byte(`{"success":true,"deleted_id":"post_1"}`))
 	}
 
 	client := testClient(t, http.HandlerFunc(handler))
 
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	deletedID, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if deletedID != "post_1" {
+		t.Errorf("expected deleted_id %q, got %q", "post_1", deletedID)
 	}
 }
 
 func TestDeletePost_InvalidID(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 
-	err := client.DeletePost(context.Background(), PostID(""))
+	_, err := client.DeletePost(context.Background(), PostID(""))
 	if err == nil {
 		t.Fatal("expected error for empty post ID")
 	}
@@ -41,7 +44,7 @@ func TestDeletePost_NotFound(t *testing.T) {
 	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found","type":"OAuthException","code":100}}`))
 	client.config.RetryConfig.MaxRetries = 0
 
-	err := client.DeletePost(context.Background(), ConvertToPostID("nonexistent"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("nonexistent"))
 	if err == nil {
 		t.Fatal("expected error for 404")
 	}
@@ -66,7 +69,7 @@ func TestDeletePostWithConfirmation_Success(t *testing.T) {
 	client := testClient(t, http.HandlerFunc(handler))
 
 	confirmed := false
-	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), func(post *Post) bool {
+	_, err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), func(post *Post) bool {
 		confirmed = true
 		return true
 	})
@@ -87,7 +90,7 @@ func TestDeletePostWithConfirmation_Cancelled(t *testing.T) {
 
 	client := testClient(t, http.HandlerFunc(handler))
 
-	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), func(post *Post) bool {
+	_, err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), func(post *Post) bool {
 		return false // user cancels
 	})
 	if err == nil {
@@ -101,7 +104,7 @@ func TestDeletePostWithConfirmation_Cancelled(t *testing.T) {
 func TestDeletePostWithConfirmation_InvalidID(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 
-	err := client.DeletePostWithConfirmation(context.Background(), PostID(""), func(post *Post) bool {
+	_, err := client.DeletePostWithConfirmation(context.Background(), PostID(""), func(post *Post) bool {
 		return true
 	})
 	if err == nil {
@@ -115,7 +118,7 @@ func TestDeletePostWithConfirmation_InvalidID(t *testing.T) {
 func TestDeletePostWithConfirmation_NilCallback(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 
-	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), nil)
+	_, err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("post_1"), nil)
 	if err == nil {
 		t.Fatal("expected error for nil callback")
 	}
@@ -128,7 +131,7 @@ func TestDeletePostWithConfirmation_GetPostError(t *testing.T) {
 	client := testClient(t, jsonHandler(404, `{"error":{"message":"not found","type":"OAuthException","code":100}}`))
 	client.config.RetryConfig.MaxRetries = 0
 
-	err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("nonexistent"), func(post *Post) bool {
+	_, err := client.DeletePostWithConfirmation(context.Background(), ConvertToPostID("nonexistent"), func(post *Post) bool {
 		return true
 	})
 	if err == nil {
@@ -152,7 +155,7 @@ func TestDeletePost_Forbidden(t *testing.T) {
 	client := testClient(t, http.HandlerFunc(handler))
 	client.config.RetryConfig.MaxRetries = 0
 
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err == nil {
 		t.Fatal("expected error for 403")
 	}
@@ -165,7 +168,7 @@ func TestDeletePost_NotAuthenticated(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 	_ = client.ClearToken()
 
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err == nil {
 		t.Fatal("expected error when not authenticated")
 	}
@@ -190,7 +193,7 @@ func TestDeletePost_ServerError(t *testing.T) {
 	client := testClient(t, http.HandlerFunc(handler))
 	client.config.RetryConfig.MaxRetries = 0
 
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err == nil {
 		t.Fatal("expected error for 500")
 	}
@@ -212,7 +215,7 @@ func TestDeletePost_Delete404(t *testing.T) {
 	client := testClient(t, http.HandlerFunc(handler))
 	client.config.RetryConfig.MaxRetries = 0
 
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err == nil {
 		t.Fatal("expected error for 404 DELETE")
 	}
@@ -238,7 +241,7 @@ func TestDeletePost_WithLogger(t *testing.T) {
 	client := testClient(t, http.HandlerFunc(handler))
 	client.config.Logger = &noopLogger{}
 
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -260,7 +263,7 @@ func TestDeletePost_MalformedDeleteResponse(t *testing.T) {
 	client := testClient(t, http.HandlerFunc(handler))
 
 	// Should succeed even with malformed response (200 status assumed success)
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -283,7 +286,7 @@ func TestDeletePost_MalformedDeleteResponseWithLogger(t *testing.T) {
 	client.config.Logger = &noopLogger{}
 
 	// Should succeed even with malformed response and logger
-	err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
+	_, err := client.DeletePost(context.Background(), ConvertToPostID("post_1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/posts_read.go
+++ b/posts_read.go
@@ -309,6 +309,10 @@ func (c *Client) GetUserGhostPosts(ctx context.Context, userID UserID, opts *Pag
 		return nil, NewValidationError(404, "User not found", fmt.Sprintf("User with ID %s does not exist or is not accessible", userID.String()), "user_id")
 	}
 
+	if resp.StatusCode == 403 {
+		return nil, NewAuthenticationError(403, "Access denied", fmt.Sprintf("Cannot access ghost posts for user %s - insufficient permissions", userID.String()))
+	}
+
 	if resp.StatusCode != 200 {
 		return nil, c.handleAPIError(resp)
 	}

--- a/posts_read.go
+++ b/posts_read.go
@@ -150,7 +150,7 @@ func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *Posts
 		return nil, err
 	}
 
-	// Validate pagination options
+	// Validate options
 	validator := NewValidator()
 	if opts != nil {
 		paginationOpts := &PaginationOptions{
@@ -160,6 +160,14 @@ func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *Posts
 		}
 		if err := validator.ValidatePaginationOptions(paginationOpts); err != nil {
 			return nil, err
+		}
+		if opts.Since > 0 && opts.Since < MinSearchTimestamp {
+			return nil, NewValidationError(400, "Invalid since timestamp",
+				fmt.Sprintf("since timestamp must be >= %d", MinSearchTimestamp), "since")
+		}
+		if opts.Until > 0 && opts.Until < MinSearchTimestamp {
+			return nil, NewValidationError(400, "Invalid until timestamp",
+				fmt.Sprintf("until timestamp must be >= %d", MinSearchTimestamp), "until")
 		}
 	}
 

--- a/posts_read.go
+++ b/posts_read.go
@@ -140,7 +140,7 @@ func (c *Client) GetUserPostsWithOptions(ctx context.Context, userID UserID, opt
 }
 
 // GetUserMentions retrieves posts where the user is mentioned
-func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *PaginationOptions) (*PostsResponse, error) {
+func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *PostsOptions) (*PostsResponse, error) {
 	if !userID.Valid() {
 		return nil, NewValidationError(400, ErrEmptyUserID, "Cannot retrieve mentions without user ID", "user_id")
 	}
@@ -152,8 +152,15 @@ func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *Pagin
 
 	// Validate pagination options
 	validator := NewValidator()
-	if err := validator.ValidatePaginationOptions(opts); err != nil {
-		return nil, err
+	if opts != nil {
+		paginationOpts := &PaginationOptions{
+			Limit:  opts.Limit,
+			Before: opts.Before,
+			After:  opts.After,
+		}
+		if err := validator.ValidatePaginationOptions(paginationOpts); err != nil {
+			return nil, err
+		}
 	}
 
 	// Build query parameters
@@ -161,7 +168,7 @@ func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *Pagin
 		"fields": {PostExtendedFields},
 	}
 
-	// Add pagination options if provided
+	// Add pagination and filtering options if provided
 	if opts != nil {
 		if opts.Limit > 0 {
 			params.Set("limit", fmt.Sprintf("%d", opts.Limit))
@@ -171,6 +178,12 @@ func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *Pagin
 		}
 		if opts.After != "" {
 			params.Set("after", opts.After)
+		}
+		if opts.Since > 0 {
+			params.Set("since", fmt.Sprintf("%d", opts.Since))
+		}
+		if opts.Until > 0 {
+			params.Set("until", fmt.Sprintf("%d", opts.Until))
 		}
 	}
 

--- a/posts_read.go
+++ b/posts_read.go
@@ -72,17 +72,10 @@ func (c *Client) GetUserPostsWithOptions(ctx context.Context, userID UserID, opt
 		return nil, err
 	}
 
-	// Validate pagination options
+	// Validate options
 	validator := NewValidator()
-	if opts != nil {
-		paginationOpts := &PaginationOptions{
-			Limit:  opts.Limit,
-			Before: opts.Before,
-			After:  opts.After,
-		}
-		if err := validator.ValidatePaginationOptions(paginationOpts); err != nil {
-			return nil, err
-		}
+	if err := validator.ValidatePostsOptions(opts); err != nil {
+		return nil, err
 	}
 
 	// Build query parameters with enhanced fields from API documentation
@@ -152,23 +145,8 @@ func (c *Client) GetUserMentions(ctx context.Context, userID UserID, opts *Posts
 
 	// Validate options
 	validator := NewValidator()
-	if opts != nil {
-		paginationOpts := &PaginationOptions{
-			Limit:  opts.Limit,
-			Before: opts.Before,
-			After:  opts.After,
-		}
-		if err := validator.ValidatePaginationOptions(paginationOpts); err != nil {
-			return nil, err
-		}
-		if opts.Since > 0 && opts.Since < MinSearchTimestamp {
-			return nil, NewValidationError(400, "Invalid since timestamp",
-				fmt.Sprintf("since timestamp must be >= %d", MinSearchTimestamp), "since")
-		}
-		if opts.Until > 0 && opts.Until < MinSearchTimestamp {
-			return nil, NewValidationError(400, "Invalid until timestamp",
-				fmt.Sprintf("until timestamp must be >= %d", MinSearchTimestamp), "until")
-		}
+	if err := validator.ValidatePostsOptions(opts); err != nil {
+		return nil, err
 	}
 
 	// Build query parameters

--- a/posts_read_test.go
+++ b/posts_read_test.go
@@ -291,6 +291,20 @@ func TestGetUserMentions_ServerError(t *testing.T) {
 	}
 }
 
+func TestGetUserMentions_InvalidSinceTimestamp(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), &PostsOptions{
+		Since: 100, // Below MinSearchTimestamp
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid since timestamp")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
 func TestGetUserGhostPosts_InvalidUserID(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 

--- a/posts_read_test.go
+++ b/posts_read_test.go
@@ -222,10 +222,36 @@ func TestGetUserMentions_WithPagination(t *testing.T) {
 
 	client := testClient(t, http.HandlerFunc(handler))
 
-	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), &PaginationOptions{
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), &PostsOptions{
 		Limit:  10,
 		Before: "cursor_before",
 		After:  "cursor_after",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetUserMentions_WithSinceUntil(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		since := r.URL.Query().Get("since")
+		until := r.URL.Query().Get("until")
+		if since != "1700000000" {
+			t.Errorf("expected since=1700000000, got %s", since)
+		}
+		if until != "1700100000" {
+			t.Errorf("expected until=1700100000, got %s", until)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data": [{"id": "1"}], "paging": {}}`))
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	_, err := client.GetUserMentions(context.Background(), ConvertToUserID("12345"), &PostsOptions{
+		Since: 1700000000,
+		Until: 1700100000,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/posts_validation.go
+++ b/posts_validation.go
@@ -38,6 +38,11 @@ func (c *Client) ValidateTextPostContent(content *TextPostContent) error {
 		return err
 	}
 
+	// Validate poll attachment if present
+	if err := validator.ValidatePollAttachment(content.PollAttachment); err != nil {
+		return err
+	}
+
 	// Text attachment can only be used with TEXT-only posts
 	if content.TextAttachment != nil {
 		// Cannot be used with polls
@@ -118,6 +123,11 @@ func (c *Client) ValidateImagePostContent(content *ImagePostContent) error {
 		return err
 	}
 
+	// Validate alt text if present
+	if err := validator.ValidateAltText(content.AltText); err != nil {
+		return err
+	}
+
 	// Validate topic tag if present
 	if content.TopicTag != "" {
 		if err := validator.ValidateTopicTag(content.TopicTag); err != nil {
@@ -160,6 +170,11 @@ func (c *Client) ValidateVideoPostContent(content *VideoPostContent) error {
 
 	// Validate video URL
 	if err := validator.ValidateMediaURL(content.VideoURL, "video"); err != nil {
+		return err
+	}
+
+	// Validate alt text if present
+	if err := validator.ValidateAltText(content.AltText); err != nil {
 		return err
 	}
 

--- a/posts_validation_test.go
+++ b/posts_validation_test.go
@@ -736,6 +736,117 @@ func TestValidateCarouselPostContent_WithTextEntities(t *testing.T) {
 	}
 }
 
+func TestValidateTextPostContent_WithValidPoll(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Which do you prefer?",
+		PollAttachment: &PollAttachment{
+			OptionA: "Option A",
+			OptionB: "Option B",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTextPostContent_PollMissingOptionA(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Which do you prefer?",
+		PollAttachment: &PollAttachment{
+			OptionA: "",
+			OptionB: "Option B",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for poll missing option A")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateTextPostContent_PollOptionTooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longOption := ""
+	for i := 0; i < MaxPollOptionLength+1; i++ {
+		longOption += "a"
+	}
+	err := client.ValidateTextPostContent(&TextPostContent{
+		Text: "Which do you prefer?",
+		PollAttachment: &PollAttachment{
+			OptionA: longOption,
+			OptionB: "Option B",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for poll option too long")
+	}
+}
+
+func TestValidateImagePostContent_WithValidAltText(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		AltText:  "A beautiful photo",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateImagePostContent_AltTextTooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longAltText := ""
+	for i := 0; i < MaxAltTextLength+1; i++ {
+		longAltText += "a"
+	}
+	err := client.ValidateImagePostContent(&ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		AltText:  longAltText,
+	})
+	if err == nil {
+		t.Fatal("expected error for alt text too long")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateVideoPostContent_WithValidAltText(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+		AltText:  "A short video clip",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVideoPostContent_AltTextTooLong(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+
+	longAltText := ""
+	for i := 0; i < MaxAltTextLength+1; i++ {
+		longAltText += "a"
+	}
+	err := client.ValidateVideoPostContent(&VideoPostContent{
+		VideoURL: "https://example.com/vid.mp4",
+		AltText:  longAltText,
+	})
+	if err == nil {
+		t.Fatal("expected error for alt text too long")
+	}
+}
+
 func TestValidateImagePostContent_TooManyLinks(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 

--- a/posts_validation_test.go
+++ b/posts_validation_test.go
@@ -772,10 +772,7 @@ func TestValidateTextPostContent_PollMissingOptionA(t *testing.T) {
 func TestValidateTextPostContent_PollOptionTooLong(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 
-	longOption := ""
-	for i := 0; i < MaxPollOptionLength+1; i++ {
-		longOption += "a"
-	}
+	longOption := strings.Repeat("a", MaxPollOptionLength+1)
 	err := client.ValidateTextPostContent(&TextPostContent{
 		Text: "Which do you prefer?",
 		PollAttachment: &PollAttachment{
@@ -803,10 +800,7 @@ func TestValidateImagePostContent_WithValidAltText(t *testing.T) {
 func TestValidateImagePostContent_AltTextTooLong(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 
-	longAltText := ""
-	for i := 0; i < MaxAltTextLength+1; i++ {
-		longAltText += "a"
-	}
+	longAltText := strings.Repeat("a", MaxAltTextLength+1)
 	err := client.ValidateImagePostContent(&ImagePostContent{
 		ImageURL: "https://example.com/img.jpg",
 		AltText:  longAltText,
@@ -834,10 +828,7 @@ func TestValidateVideoPostContent_WithValidAltText(t *testing.T) {
 func TestValidateVideoPostContent_AltTextTooLong(t *testing.T) {
 	client := testClient(t, jsonHandler(200, `{}`))
 
-	longAltText := ""
-	for i := 0; i < MaxAltTextLength+1; i++ {
-		longAltText += "a"
-	}
+	longAltText := strings.Repeat("a", MaxAltTextLength+1)
 	err := client.ValidateVideoPostContent(&VideoPostContent{
 		VideoURL: "https://example.com/vid.mp4",
 		AltText:  longAltText,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -237,7 +237,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 
 		// Clean up - delete the test post using public API
 		time.Sleep(1 * time.Second) // Wait a bit before deletion
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete test post %s: %v", post.ID, err)
 		} else {
@@ -274,7 +274,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 
 		// Clean up - delete the test post
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete image post %s: %v", post.ID, err)
 		} else {
@@ -313,7 +313,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 
 		// Clean up - delete the test post
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete video post %s: %v", post.ID, err)
 		} else {
@@ -367,7 +367,7 @@ func TestIntegration_PostOperations(t *testing.T) {
 
 		// Clean up - delete the test post
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete carousel post %s: %v", post.ID, err)
 		} else {
@@ -491,7 +491,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete spoiler post %s: %v", post.ID, err)
 		} else {
@@ -527,7 +527,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete multi-spoiler post %s: %v", post.ID, err)
 		}
@@ -556,7 +556,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete image spoiler post %s: %v", post.ID, err)
 		}
@@ -591,7 +591,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete combined spoiler post %s: %v", post.ID, err)
 		}
@@ -630,7 +630,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete text attachment post %s: %v", post.ID, err)
 		}
@@ -656,7 +656,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete text attachment link post %s: %v", post.ID, err)
 		}
@@ -699,7 +699,7 @@ func TestIntegration_SpoilersAndTextAttachments(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete carousel spoiler post %s: %v", post.ID, err)
 		}
@@ -977,7 +977,7 @@ func TestIntegration_GIFPosts(t *testing.T) {
 
 		// Clean up - delete the test post
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete GIF post %s: %v", post.ID, err)
 		} else {
@@ -1005,7 +1005,7 @@ func TestIntegration_GIFPosts(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete GIF post %s: %v", post.ID, err)
 		}
@@ -1116,7 +1116,7 @@ func TestIntegration_ReplyApprovals(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete test post %s: %v", post.ID, err)
 		} else {
@@ -1145,7 +1145,7 @@ func TestIntegration_ReplyApprovals(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete image post %s: %v", post.ID, err)
 		}
@@ -1177,7 +1177,7 @@ func TestIntegration_ReplyApprovals(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete test post %s: %v", post.ID, err)
 		}
@@ -1232,7 +1232,7 @@ func TestIntegration_ReplyApprovalsValidation(t *testing.T) {
 
 		// Clean up
 		time.Sleep(1 * time.Second)
-		err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
+		_, err = client.DeletePost(context.Background(), threads.ConvertToPostID(post.ID))
 		if err != nil {
 			t.Logf("Warning: Failed to delete test post %s: %v", post.ID, err)
 		}

--- a/types.go
+++ b/types.go
@@ -91,20 +91,27 @@ type Post struct {
 	Location                *Location       `json:"location,omitempty"`
 }
 
+// RecentSearch represents a recently searched keyword with its timestamp
+type RecentSearch struct {
+	Query     string `json:"query"`
+	Timestamp int64  `json:"timestamp"`
+}
+
 // User represents a Threads user profile with app-scoped data.
 // The user ID and other fields are specific to your app and cannot be used
 // with other apps. Contains basic profile information accessible via API.
 type User struct {
-	ID                     string `json:"id"`
-	Username               string `json:"username"`
-	Name                   string `json:"name,omitempty"`                       // Available with appropriate fields
-	ProfilePicURL          string `json:"profile_pic_url,omitempty"`            // Maps to threads_profile_picture_url
-	Biography              string `json:"biography,omitempty"`                  // Maps to threads_biography
-	Website                string `json:"website,omitempty"`                    // Not available in basic profile
-	FollowersCount         int    `json:"followers_count"`                      // Not available in basic profile
-	MediaCount             int    `json:"media_count"`                          // Not available in basic profile
-	IsVerified             bool   `json:"is_verified,omitempty"`                // Available with is_verified field
-	IsEligibleForGeoGating bool   `json:"is_eligible_for_geo_gating,omitempty"` // Whether geo-gating is available for this user
+	ID                       string         `json:"id"`
+	Username                 string         `json:"username"`
+	Name                     string         `json:"name,omitempty"`                       // Available with appropriate fields
+	ProfilePicURL            string         `json:"profile_pic_url,omitempty"`            // Maps to threads_profile_picture_url
+	Biography                string         `json:"biography,omitempty"`                  // Maps to threads_biography
+	Website                  string         `json:"website,omitempty"`                    // Not available in basic profile
+	FollowersCount           int            `json:"followers_count"`                      // Not available in basic profile
+	MediaCount               int            `json:"media_count"`                          // Not available in basic profile
+	IsVerified               bool           `json:"is_verified,omitempty"`                // Available with is_verified field
+	IsEligibleForGeoGating   bool           `json:"is_eligible_for_geo_gating,omitempty"` // Whether geo-gating is available for this user
+	RecentlySearchedKeywords []RecentSearch `json:"recently_searched_keywords,omitempty"` // Recently searched keywords with timestamps
 }
 
 // PublicUser represents a public Threads user profile retrieved via the

--- a/types.go
+++ b/types.go
@@ -82,22 +82,29 @@ type Post struct {
 	// Available for replies and mentions. For conversations, only available on direct replies.
 	ProfilePictureURL string `json:"profile_picture_url,omitempty"`
 	// ReplyApprovalStatus is the approval status of a pending reply ("pending" or "ignored")
-	ReplyApprovalStatus string `json:"reply_approval_status,omitempty"`
+	ReplyApprovalStatus     string          `json:"reply_approval_status,omitempty"`
+	IsSpoilerMedia          bool            `json:"is_spoiler_media,omitempty"`
+	TextEntities            []TextEntity    `json:"text_entities,omitempty"`
+	TextAttachment          *TextAttachment `json:"text_attachment,omitempty"`
+	AllowlistedCountryCodes []string        `json:"allowlisted_country_codes,omitempty"`
+	LocationID              string          `json:"location_id,omitempty"`
+	Location                *Location       `json:"location,omitempty"`
 }
 
 // User represents a Threads user profile with app-scoped data.
 // The user ID and other fields are specific to your app and cannot be used
 // with other apps. Contains basic profile information accessible via API.
 type User struct {
-	ID             string `json:"id"`
-	Username       string `json:"username"`
-	Name           string `json:"name,omitempty"`            // Available with appropriate fields
-	ProfilePicURL  string `json:"profile_pic_url,omitempty"` // Maps to threads_profile_picture_url
-	Biography      string `json:"biography,omitempty"`       // Maps to threads_biography
-	Website        string `json:"website,omitempty"`         // Not available in basic profile
-	FollowersCount int    `json:"followers_count"`           // Not available in basic profile
-	MediaCount     int    `json:"media_count"`               // Not available in basic profile
-	IsVerified     bool   `json:"is_verified,omitempty"`     // Available with is_verified field
+	ID                     string `json:"id"`
+	Username               string `json:"username"`
+	Name                   string `json:"name,omitempty"`                       // Available with appropriate fields
+	ProfilePicURL          string `json:"profile_pic_url,omitempty"`            // Maps to threads_profile_picture_url
+	Biography              string `json:"biography,omitempty"`                  // Maps to threads_biography
+	Website                string `json:"website,omitempty"`                    // Not available in basic profile
+	FollowersCount         int    `json:"followers_count"`                      // Not available in basic profile
+	MediaCount             int    `json:"media_count"`                          // Not available in basic profile
+	IsVerified             bool   `json:"is_verified,omitempty"`                // Available with is_verified field
+	IsEligibleForGeoGating bool   `json:"is_eligible_for_geo_gating,omitempty"` // Whether geo-gating is available for this user
 }
 
 // PublicUser represents a public Threads user profile retrieved via the
@@ -242,6 +249,31 @@ const (
 	ReplyControlFollowersOnly ReplyControl = "followers_only"
 )
 
+// ReplyAudience represents the audience restriction returned by the API when reading posts.
+// This is the read-side counterpart to ReplyControl (which is used for creation).
+// The API returns reply_audience in UPPERCASE values.
+type ReplyAudience string
+
+const (
+	ReplyAudienceEveryone             ReplyAudience = "EVERYONE"
+	ReplyAudienceAccountsYouFollow    ReplyAudience = "ACCOUNTS_YOU_FOLLOW"
+	ReplyAudienceMentionedOnly        ReplyAudience = "MENTIONED_ONLY"
+	ReplyAudienceParentPostAuthorOnly ReplyAudience = "PARENT_POST_AUTHOR_ONLY"
+	ReplyAudienceFollowersOnly        ReplyAudience = "FOLLOWERS_ONLY"
+)
+
+// HideStatus represents the visibility status of a reply
+type HideStatus string
+
+const (
+	HideStatusNotHushed  HideStatus = "NOT_HUSHED"
+	HideStatusUnhushed   HideStatus = "UNHUSHED"
+	HideStatusHidden     HideStatus = "HIDDEN"
+	HideStatusCovered    HideStatus = "COVERED"
+	HideStatusBlocked    HideStatus = "BLOCKED"
+	HideStatusRestricted HideStatus = "RESTRICTED"
+)
+
 // PostsResponse represents a paginated response containing multiple posts.
 // Use the Paging field to navigate through large result sets.
 // This is returned by endpoints like GetUserPosts, SearchPosts, etc.
@@ -286,7 +318,8 @@ type Value struct {
 
 // TotalValue represents an aggregated metric value
 type TotalValue struct {
-	Value int `json:"value"`
+	Value   int    `json:"value"`
+	LinkURL string `json:"link_url,omitempty"` // URL for click metrics
 }
 
 // Paging represents pagination information for navigating through result sets.
@@ -396,6 +429,8 @@ type PublishingLimits struct {
 	DeleteConfig             QuotaConfig `json:"delete_config"`
 	LocationSearchQuotaUsage int         `json:"location_search_quota_usage"`
 	LocationSearchConfig     QuotaConfig `json:"location_search_config"`
+	SearchQuotaUsage         int         `json:"search_quota_usage"`
+	SearchConfig             QuotaConfig `json:"search_config"`
 }
 
 // QuotaConfig represents quota configuration for a specific operation type.

--- a/types.go
+++ b/types.go
@@ -63,7 +63,7 @@ type Post struct {
 	IsQuotePost                  bool          `json:"is_quote_post,omitempty"`
 	LinkAttachmentURL            string        `json:"link_attachment_url,omitempty"`
 	HasReplies                   bool          `json:"has_replies,omitempty"`
-	ReplyAudience                string        `json:"reply_audience,omitempty"`
+	ReplyAudience                ReplyAudience `json:"reply_audience,omitempty"`
 	QuotedPost                   *Post         `json:"quoted_post,omitempty"`
 	RepostedPost                 *Post         `json:"reposted_post,omitempty"`
 	GifURL                       string        `json:"gif_url,omitempty"`
@@ -71,7 +71,7 @@ type Post struct {
 	RootPost                     *Post         `json:"root_post,omitempty"`
 	RepliedTo                    *Post         `json:"replied_to,omitempty"`
 	IsReplyOwnedByMe             bool          `json:"is_reply_owned_by_me,omitempty"`
-	HideStatus                   string        `json:"hide_status,omitempty"`
+	HideStatus                   HideStatus    `json:"hide_status,omitempty"`
 	TopicTag                     string        `json:"topic_tag,omitempty"`
 	GhostPostStatus              string        `json:"ghost_post_status,omitempty"`
 	GhostPostExpirationTimestamp Time          `json:"ghost_post_expiration_timestamp,omitempty"`

--- a/types.go
+++ b/types.go
@@ -443,6 +443,17 @@ type PublishingLimits struct {
 // QuotaConfig represents quota configuration for a specific operation type.
 // QuotaTotal is the maximum allowed operations, QuotaDuration is the time window
 // in seconds during which the quota applies.
+//
+// Rate limit defaults per the API documentation:
+//   - Posts: 250 per 24 hours
+//   - Replies: 1000 per 24 hours
+//   - Deletes: 100 per 24 hours
+//   - Search: 2200 per 24 hours
+//   - Location search: 500 per 24 hours
+//
+// Additionally, API calls are subject to a rate limit calculated as
+// 4800 × Number of Impressions (minimum 10 impressions), with separate
+// CPU-time based limits.
 type QuotaConfig struct {
 	QuotaTotal    int `json:"quota_total"`
 	QuotaDuration int `json:"quota_duration"`

--- a/types.go
+++ b/types.go
@@ -45,36 +45,39 @@ func (t *Time) MarshalJSON() ([]byte, error) {
 // This is the primary data structure returned by most post-related API operations.
 // Posts can contain text, images, videos, carousels, or be quote/reply posts.
 type Post struct {
-	ID                           string        `json:"id"`
-	Text                         string        `json:"text,omitempty"`
-	MediaType                    string        `json:"media_type,omitempty"`
-	MediaURL                     string        `json:"media_url,omitempty"`
-	Permalink                    string        `json:"permalink"`
-	Timestamp                    Time          `json:"timestamp"`
-	Username                     string        `json:"username"`
-	Owner                        *PostOwner    `json:"owner,omitempty"`
-	IsReply                      bool          `json:"is_reply"`
-	ReplyTo                      string        `json:"reply_to,omitempty"`
-	MediaProductType             string        `json:"media_product_type"`
-	Shortcode                    string        `json:"shortcode,omitempty"`
-	ThumbnailURL                 string        `json:"thumbnail_url,omitempty"`
-	AltText                      string        `json:"alt_text,omitempty"`
-	Children                     *ChildrenData `json:"children,omitempty"`
-	IsQuotePost                  bool          `json:"is_quote_post,omitempty"`
-	LinkAttachmentURL            string        `json:"link_attachment_url,omitempty"`
-	HasReplies                   bool          `json:"has_replies,omitempty"`
-	ReplyAudience                ReplyAudience `json:"reply_audience,omitempty"`
-	QuotedPost                   *Post         `json:"quoted_post,omitempty"`
-	RepostedPost                 *Post         `json:"reposted_post,omitempty"`
-	GifURL                       string        `json:"gif_url,omitempty"`
-	PollAttachment               *PollResult   `json:"poll_attachment,omitempty"`
-	RootPost                     *Post         `json:"root_post,omitempty"`
-	RepliedTo                    *Post         `json:"replied_to,omitempty"`
-	IsReplyOwnedByMe             bool          `json:"is_reply_owned_by_me,omitempty"`
-	HideStatus                   HideStatus    `json:"hide_status,omitempty"`
-	TopicTag                     string        `json:"topic_tag,omitempty"`
-	GhostPostStatus              string        `json:"ghost_post_status,omitempty"`
-	GhostPostExpirationTimestamp Time          `json:"ghost_post_expiration_timestamp,omitempty"`
+	ID                string        `json:"id"`
+	Text              string        `json:"text,omitempty"`
+	MediaType         string        `json:"media_type,omitempty"`
+	MediaURL          string        `json:"media_url,omitempty"`
+	Permalink         string        `json:"permalink"`
+	Timestamp         Time          `json:"timestamp"`
+	Username          string        `json:"username"`
+	Owner             *PostOwner    `json:"owner,omitempty"`
+	IsReply           bool          `json:"is_reply"`
+	ReplyTo           string        `json:"reply_to,omitempty"`
+	MediaProductType  string        `json:"media_product_type"`
+	Shortcode         string        `json:"shortcode,omitempty"`
+	ThumbnailURL      string        `json:"thumbnail_url,omitempty"`
+	AltText           string        `json:"alt_text,omitempty"`
+	Children          *ChildrenData `json:"children,omitempty"`
+	IsQuotePost       bool          `json:"is_quote_post,omitempty"`
+	LinkAttachmentURL string        `json:"link_attachment_url,omitempty"`
+	HasReplies        bool          `json:"has_replies,omitempty"`
+	ReplyAudience     ReplyAudience `json:"reply_audience,omitempty"`
+	QuotedPost        *Post         `json:"quoted_post,omitempty"`
+	RepostedPost      *Post         `json:"reposted_post,omitempty"`
+	GifURL            string        `json:"gif_url,omitempty"`
+	PollAttachment    *PollResult   `json:"poll_attachment,omitempty"`
+	RootPost          *Post         `json:"root_post,omitempty"`
+	RepliedTo         *Post         `json:"replied_to,omitempty"`
+	IsReplyOwnedByMe  bool          `json:"is_reply_owned_by_me,omitempty"`
+	HideStatus        HideStatus    `json:"hide_status,omitempty"`
+	TopicTag          string        `json:"topic_tag,omitempty"`
+	GhostPostStatus   string        `json:"ghost_post_status,omitempty"`
+	// GhostPostExpirationTimestamp is only present for ghost posts (ghost_post_status != "").
+	// omitempty is safe here: the zero Time value is omitted on marshal, and absent fields
+	// are left at zero on unmarshal.
+	GhostPostExpirationTimestamp Time `json:"ghost_post_expiration_timestamp,omitempty"`
 	// IsVerified indicates if the post author's profile is verified on Threads.
 	// Available for replies and mentions. For conversations, only available on direct replies.
 	IsVerified bool `json:"is_verified,omitempty"`

--- a/types.go
+++ b/types.go
@@ -82,13 +82,13 @@ type Post struct {
 	// Available for replies and mentions. For conversations, only available on direct replies.
 	ProfilePictureURL string `json:"profile_picture_url,omitempty"`
 	// ReplyApprovalStatus is the approval status of a pending reply ("pending" or "ignored")
-	ReplyApprovalStatus     string          `json:"reply_approval_status,omitempty"`
-	IsSpoilerMedia          bool            `json:"is_spoiler_media,omitempty"`
+	ReplyApprovalStatus     string                `json:"reply_approval_status,omitempty"`
+	IsSpoilerMedia          bool                  `json:"is_spoiler_media,omitempty"`
 	TextEntities            *TextEntitiesResponse `json:"text_entities,omitempty"`
-	TextAttachment          *TextAttachment `json:"text_attachment,omitempty"`
-	AllowlistedCountryCodes []string        `json:"allowlisted_country_codes,omitempty"`
-	LocationID              string          `json:"location_id,omitempty"`
-	Location                *Location       `json:"location,omitempty"`
+	TextAttachment          *TextAttachment       `json:"text_attachment,omitempty"`
+	AllowlistedCountryCodes []string              `json:"allowlisted_country_codes,omitempty"`
+	LocationID              string                `json:"location_id,omitempty"`
+	Location                *Location             `json:"location,omitempty"`
 }
 
 // RecentSearch represents a recently searched keyword with its timestamp

--- a/types.go
+++ b/types.go
@@ -84,7 +84,7 @@ type Post struct {
 	// ReplyApprovalStatus is the approval status of a pending reply ("pending" or "ignored")
 	ReplyApprovalStatus     string          `json:"reply_approval_status,omitempty"`
 	IsSpoilerMedia          bool            `json:"is_spoiler_media,omitempty"`
-	TextEntities            []TextEntity    `json:"text_entities,omitempty"`
+	TextEntities            *TextEntitiesResponse `json:"text_entities,omitempty"`
 	TextAttachment          *TextAttachment `json:"text_attachment,omitempty"`
 	AllowlistedCountryCodes []string        `json:"allowlisted_country_codes,omitempty"`
 	LocationID              string          `json:"location_id,omitempty"`
@@ -543,6 +543,12 @@ type TextEntity struct {
 	EntityType string `json:"entity_type"` // "SPOILER" or "spoiler"
 	Offset     int    `json:"offset"`      // Starting position of the spoiler (0-indexed)
 	Length     int    `json:"length"`      // Length of the spoiler text from offset
+}
+
+// TextEntitiesResponse wraps text entities as returned by the API.
+// The API returns text_entities as {"data": [...]} rather than a flat array.
+type TextEntitiesResponse struct {
+	Data []TextEntity `json:"data"`
 }
 
 // TextAttachment represents a text attachment with optional styling

--- a/users.go
+++ b/users.go
@@ -104,6 +104,7 @@ func (c *Client) GetUserFields(ctx context.Context, userID UserID, fields []stri
 		"threads_biography":           true,
 		"is_verified":                 true,
 		"recently_searched_keywords":  true,
+		"is_eligible_for_geo_gating":  true,
 	}
 
 	var validFields []string
@@ -149,13 +150,14 @@ func (c *Client) GetUserFields(ctx context.Context, userID UserID, fields []stri
 
 	// Parse response with all possible fields
 	var apiUser struct {
-		ID                       string   `json:"id"`
-		Username                 string   `json:"username"`
-		Name                     string   `json:"name,omitempty"`
-		ThreadsProfilePictureURL string   `json:"threads_profile_picture_url,omitempty"`
-		ThreadsBiography         string   `json:"threads_biography,omitempty"`
-		IsVerified               bool     `json:"is_verified,omitempty"`
-		RecentlySearchedKeywords []string `json:"recently_searched_keywords,omitempty"`
+		ID                       string         `json:"id"`
+		Username                 string         `json:"username"`
+		Name                     string         `json:"name,omitempty"`
+		ThreadsProfilePictureURL string         `json:"threads_profile_picture_url,omitempty"`
+		ThreadsBiography         string         `json:"threads_biography,omitempty"`
+		IsVerified               bool           `json:"is_verified,omitempty"`
+		RecentlySearchedKeywords []RecentSearch `json:"recently_searched_keywords,omitempty"`
+		IsEligibleForGeoGating   bool           `json:"is_eligible_for_geo_gating,omitempty"`
 	}
 
 	if err := safeJSONUnmarshal(resp.Body, &apiUser, "user response", resp.RequestID); err != nil {
@@ -164,12 +166,14 @@ func (c *Client) GetUserFields(ctx context.Context, userID UserID, fields []stri
 
 	// Convert to our User struct format
 	user := &User{
-		ID:            apiUser.ID,
-		Username:      apiUser.Username,
-		Name:          apiUser.Name,
-		ProfilePicURL: apiUser.ThreadsProfilePictureURL,
-		Biography:     apiUser.ThreadsBiography,
-		IsVerified:    apiUser.IsVerified,
+		ID:                       apiUser.ID,
+		Username:                 apiUser.Username,
+		Name:                     apiUser.Name,
+		ProfilePicURL:            apiUser.ThreadsProfilePictureURL,
+		Biography:                apiUser.ThreadsBiography,
+		IsVerified:               apiUser.IsVerified,
+		RecentlySearchedKeywords: apiUser.RecentlySearchedKeywords,
+		IsEligibleForGeoGating:   apiUser.IsEligibleForGeoGating,
 	}
 
 	return user, nil

--- a/users.go
+++ b/users.go
@@ -237,6 +237,12 @@ func (c *Client) GetPublicProfilePosts(ctx context.Context, username string, opt
 		return nil, err
 	}
 
+	// Validate options
+	validator := NewValidator()
+	if err := validator.ValidatePostsOptions(opts); err != nil {
+		return nil, err
+	}
+
 	// Build query parameters with enhanced fields from API documentation
 	params := url.Values{
 		"username": {username},
@@ -246,9 +252,6 @@ func (c *Client) GetPublicProfilePosts(ctx context.Context, username string, opt
 	// Add pagination and filtering options if provided
 	if opts != nil {
 		if opts.Limit > 0 {
-			if opts.Limit > 100 {
-				return nil, NewValidationError(400, "Limit too large", "Maximum limit is 100 posts per request", "limit")
-			}
 			params.Set("limit", fmt.Sprintf("%d", opts.Limit))
 		}
 		if opts.Before != "" {
@@ -301,6 +304,12 @@ func (c *Client) GetUserReplies(ctx context.Context, userID UserID, opts *PostsO
 		return nil, err
 	}
 
+	// Validate options
+	validator := NewValidator()
+	if err := validator.ValidatePostsOptions(opts); err != nil {
+		return nil, err
+	}
+
 	// Build query parameters with reply-specific fields from API documentation
 	params := url.Values{
 		"fields": {ReplyFields},
@@ -309,9 +318,6 @@ func (c *Client) GetUserReplies(ctx context.Context, userID UserID, opts *PostsO
 	// Add pagination and filtering options if provided
 	if opts != nil {
 		if opts.Limit > 0 {
-			if opts.Limit > 100 {
-				return nil, NewValidationError(400, "Limit too large", "Maximum limit is 100 replies per request", "limit")
-			}
 			params.Set("limit", fmt.Sprintf("%d", opts.Limit))
 		}
 		if opts.Before != "" {

--- a/users_test.go
+++ b/users_test.go
@@ -274,11 +274,11 @@ func TestGetPublicProfilePosts_WithOptions(t *testing.T) {
 		if q.Get("after") != "cursor_after" {
 			t.Errorf("expected after=cursor_after, got %s", q.Get("after"))
 		}
-		if q.Get("since") != "1000000" {
-			t.Errorf("expected since=1000000, got %s", q.Get("since"))
+		if q.Get("since") != "1700000000" {
+			t.Errorf("expected since=1700000000, got %s", q.Get("since"))
 		}
-		if q.Get("until") != "2000000" {
-			t.Errorf("expected until=2000000, got %s", q.Get("until"))
+		if q.Get("until") != "1700100000" {
+			t.Errorf("expected until=1700100000, got %s", q.Get("until"))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
@@ -289,8 +289,8 @@ func TestGetPublicProfilePosts_WithOptions(t *testing.T) {
 		Limit:  10,
 		Before: "cursor_before",
 		After:  "cursor_after",
-		Since:  1000000,
-		Until:  2000000,
+		Since:  1700000000,
+		Until:  1700100000,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -359,11 +359,11 @@ func TestGetUserReplies_WithOptions(t *testing.T) {
 		if q.Get("after") != "a_cursor" {
 			t.Errorf("expected after=a_cursor, got %s", q.Get("after"))
 		}
-		if q.Get("since") != "100" {
-			t.Errorf("expected since=100, got %s", q.Get("since"))
+		if q.Get("since") != "1700000000" {
+			t.Errorf("expected since=1700000000, got %s", q.Get("since"))
 		}
-		if q.Get("until") != "200" {
-			t.Errorf("expected until=200, got %s", q.Get("until"))
+		if q.Get("until") != "1700100000" {
+			t.Errorf("expected until=1700100000, got %s", q.Get("until"))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
@@ -374,8 +374,8 @@ func TestGetUserReplies_WithOptions(t *testing.T) {
 		Limit:  5,
 		Before: "b_cursor",
 		After:  "a_cursor",
-		Since:  100,
-		Until:  200,
+		Since:  1700000000,
+		Until:  1700100000,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/users_test.go
+++ b/users_test.go
@@ -470,6 +470,50 @@ func TestGetUserFields_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestGetUserFields_RecentlySearchedKeywords(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{
+		"id": "12345",
+		"username": "testuser",
+		"recently_searched_keywords": [
+			{"query": "golang", "timestamp": 1700000001},
+			{"query": "threads api", "timestamp": 1700000002}
+		]
+	}`))
+
+	user, err := client.GetUserFields(context.Background(), ConvertToUserID("12345"), []string{"id", "recently_searched_keywords"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(user.RecentlySearchedKeywords) != 2 {
+		t.Fatalf("expected 2 recently searched keywords, got %d", len(user.RecentlySearchedKeywords))
+	}
+	if user.RecentlySearchedKeywords[0].Query != "golang" {
+		t.Errorf("expected first keyword query 'golang', got %s", user.RecentlySearchedKeywords[0].Query)
+	}
+	if user.RecentlySearchedKeywords[0].Timestamp != 1700000001 {
+		t.Errorf("expected first keyword timestamp 1700000001, got %d", user.RecentlySearchedKeywords[0].Timestamp)
+	}
+	if user.RecentlySearchedKeywords[1].Query != "threads api" {
+		t.Errorf("expected second keyword query 'threads api', got %s", user.RecentlySearchedKeywords[1].Query)
+	}
+}
+
+func TestGetUserFields_IsEligibleForGeoGating(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{
+		"id": "12345",
+		"username": "testuser",
+		"is_eligible_for_geo_gating": true
+	}`))
+
+	user, err := client.GetUserFields(context.Background(), ConvertToUserID("12345"), []string{"id", "is_eligible_for_geo_gating"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !user.IsEligibleForGeoGating {
+		t.Error("expected is_eligible_for_geo_gating to be true")
+	}
+}
+
 func TestGetPublicProfilePosts_NoAuth(t *testing.T) {
 	client := testClientNoAuth(t, jsonHandler(200, `{}`))
 	_, err := client.GetPublicProfilePosts(context.Background(), "testuser", nil)

--- a/validation.go
+++ b/validation.go
@@ -154,17 +154,17 @@ func (v *Validator) ValidatePollAttachment(poll *PollAttachment) error {
 		return nil // Poll attachment is optional
 	}
 
-	// Options A and B are required
+	// Options A and B are required (MinPollOptions = 2)
 	if poll.OptionA == "" {
 		return NewValidationError(400,
 			"Poll option A required",
-			"Poll attachment must have option_a",
+			fmt.Sprintf("Poll attachment must have at least %d options (option_a is required)", MinPollOptions),
 			"poll_attachment.option_a")
 	}
 	if poll.OptionB == "" {
 		return NewValidationError(400,
 			"Poll option B required",
-			"Poll attachment must have option_b",
+			fmt.Sprintf("Poll attachment must have at least %d options (option_b is required)", MinPollOptions),
 			"poll_attachment.option_b")
 	}
 
@@ -402,6 +402,10 @@ func (v *Validator) ValidatePostsOptions(opts *PostsOptions) error {
 	if opts.Until > 0 && opts.Until < MinSearchTimestamp {
 		return NewValidationError(400, "Invalid until timestamp",
 			fmt.Sprintf("until timestamp must be >= %d", MinSearchTimestamp), "until")
+	}
+	if opts.Since > 0 && opts.Until > 0 && opts.Since > opts.Until {
+		return NewValidationError(400, "Invalid time range",
+			"since timestamp must be less than or equal to until timestamp", "since")
 	}
 
 	return nil

--- a/validation.go
+++ b/validation.go
@@ -381,6 +381,32 @@ func (v *Validator) ValidatePaginationOptions(opts *PaginationOptions) error {
 	return nil
 }
 
+// ValidatePostsOptions validates PostsOptions including pagination and timestamp fields.
+func (v *Validator) ValidatePostsOptions(opts *PostsOptions) error {
+	if opts == nil {
+		return nil
+	}
+
+	if err := v.ValidatePaginationOptions(&PaginationOptions{
+		Limit:  opts.Limit,
+		Before: opts.Before,
+		After:  opts.After,
+	}); err != nil {
+		return err
+	}
+
+	if opts.Since > 0 && opts.Since < MinSearchTimestamp {
+		return NewValidationError(400, "Invalid since timestamp",
+			fmt.Sprintf("since timestamp must be >= %d", MinSearchTimestamp), "since")
+	}
+	if opts.Until > 0 && opts.Until < MinSearchTimestamp {
+		return NewValidationError(400, "Invalid until timestamp",
+			fmt.Sprintf("until timestamp must be >= %d", MinSearchTimestamp), "until")
+	}
+
+	return nil
+}
+
 // ValidateSearchOptions validates search parameters
 func (v *Validator) ValidateSearchOptions(opts *SearchOptions) error {
 	if opts == nil {

--- a/validation.go
+++ b/validation.go
@@ -191,6 +191,12 @@ func (v *Validator) ValidatePollAttachment(poll *PollAttachment) error {
 		if opt.value == "" {
 			continue // optional options can be empty
 		}
+		if strings.TrimSpace(opt.value) == "" {
+			return NewValidationError(400,
+				"Poll option cannot be blank",
+				fmt.Sprintf("Poll option in %s must contain non-whitespace characters", opt.field),
+				opt.field)
+		}
 		if utf8.RuneCountInString(opt.value) > MaxPollOptionLength {
 			return NewValidationError(400,
 				"Poll option too long",

--- a/validation.go
+++ b/validation.go
@@ -106,9 +106,28 @@ func (v *Validator) ValidateTextAttachment(textAttachment *TextAttachment) error
 	return nil
 }
 
-// validateTextStylingRanges checks that text styling ranges don't overlap
+// validateTextStylingRanges checks that text styling ranges don't overlap and that
+// each styling entry contains only valid style values.
 func (v *Validator) validateTextStylingRanges(stylingInfo []TextStylingInfo) error {
+	validStyles := map[string]bool{
+		"bold":          true,
+		"italic":        true,
+		"highlight":     true,
+		"underline":     true,
+		"strikethrough": true,
+	}
+
 	for i := 0; i < len(stylingInfo); i++ {
+		// Validate style values
+		for _, style := range stylingInfo[i].StylingInfo {
+			if !validStyles[style] {
+				return NewValidationError(400,
+					"Invalid text styling value",
+					fmt.Sprintf("Text styling range %d contains invalid style '%s'. Valid styles are: bold, italic, highlight, underline, strikethrough", i, style),
+					"text_attachment.text_with_styling_info")
+			}
+		}
+
 		for j := i + 1; j < len(stylingInfo); j++ {
 			// Check if ranges overlap
 			start1, end1 := stylingInfo[i].Offset, stylingInfo[i].Offset+stylingInfo[i].Length
@@ -122,6 +141,69 @@ func (v *Validator) validateTextStylingRanges(stylingInfo []TextStylingInfo) err
 					"text_attachment.text_with_styling_info")
 			}
 		}
+	}
+	return nil
+}
+
+// ValidatePollAttachment validates poll attachment options.
+// Options A and B are required; options C and D are optional.
+// Each provided option must be 1-25 characters.
+func (v *Validator) ValidatePollAttachment(poll *PollAttachment) error {
+	if poll == nil {
+		return nil // Poll attachment is optional
+	}
+
+	// Options A and B are required
+	if poll.OptionA == "" {
+		return NewValidationError(400,
+			"Poll option A required",
+			"Poll attachment must have option_a",
+			"poll_attachment.option_a")
+	}
+	if poll.OptionB == "" {
+		return NewValidationError(400,
+			"Poll option B required",
+			"Poll attachment must have option_b",
+			"poll_attachment.option_b")
+	}
+
+	// Validate length of each provided option
+	options := []struct {
+		value string
+		field string
+	}{
+		{poll.OptionA, "poll_attachment.option_a"},
+		{poll.OptionB, "poll_attachment.option_b"},
+		{poll.OptionC, "poll_attachment.option_c"},
+		{poll.OptionD, "poll_attachment.option_d"},
+	}
+
+	for _, opt := range options {
+		if opt.value == "" {
+			continue // optional options can be empty
+		}
+		if utf8.RuneCountInString(opt.value) > MaxPollOptionLength {
+			return NewValidationError(400,
+				"Poll option too long",
+				fmt.Sprintf("Poll option in %s must be at most %d characters", opt.field, MaxPollOptionLength),
+				opt.field)
+		}
+	}
+
+	return nil
+}
+
+// ValidateAltText validates alt text for media posts.
+// Alt text is optional but cannot exceed MaxAltTextLength characters.
+func (v *Validator) ValidateAltText(altText string) error {
+	if altText == "" {
+		return nil // Alt text is optional
+	}
+	if utf8.RuneCountInString(altText) > MaxAltTextLength {
+		return NewValidationError(400,
+			"Alt text too long",
+			fmt.Sprintf("Alt text is limited to %d characters", MaxAltTextLength),
+			"alt_text")
 	}
 	return nil
 }

--- a/validation.go
+++ b/validation.go
@@ -146,8 +146,9 @@ func (v *Validator) validateTextStylingRanges(stylingInfo []TextStylingInfo) err
 }
 
 // ValidatePollAttachment validates poll attachment options.
+// The API requires MinPollOptions (2) to MaxPollOptions (4) options.
 // Options A and B are required; options C and D are optional.
-// Each provided option must be 1-25 characters.
+// Each provided option must be 1-MaxPollOptionLength (25) characters.
 func (v *Validator) ValidatePollAttachment(poll *PollAttachment) error {
 	if poll == nil {
 		return nil // Poll attachment is optional

--- a/validation.go
+++ b/validation.go
@@ -168,6 +168,14 @@ func (v *Validator) ValidatePollAttachment(poll *PollAttachment) error {
 			"poll_attachment.option_b")
 	}
 
+	// Options must be sequential: D requires C
+	if poll.OptionD != "" && poll.OptionC == "" {
+		return NewValidationError(400,
+			"Poll option C required before D",
+			"Cannot set option_d without option_c",
+			"poll_attachment.option_c")
+	}
+
 	// Validate length of each provided option
 	options := []struct {
 		value string

--- a/validation_test.go
+++ b/validation_test.go
@@ -406,6 +406,19 @@ func TestValidatePollAttachment(t *testing.T) {
 		}
 	})
 
+	t.Run("whitespace-only option returns error", func(t *testing.T) {
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: "Yes",
+			OptionB: "   ",
+		})
+		if err == nil {
+			t.Fatal("Expected error for whitespace-only option")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
 	t.Run("option at max length is valid", func(t *testing.T) {
 		maxStr := strings.Repeat("a", MaxPollOptionLength)
 		err := v.ValidatePollAttachment(&PollAttachment{

--- a/validation_test.go
+++ b/validation_test.go
@@ -392,6 +392,20 @@ func TestValidatePollAttachment(t *testing.T) {
 		}
 	})
 
+	t.Run("option D without C returns error", func(t *testing.T) {
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: "Yes",
+			OptionB: "No",
+			OptionD: "Maybe",
+		})
+		if err == nil {
+			t.Fatal("Expected error for option D without option C")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
 	t.Run("option at max length is valid", func(t *testing.T) {
 		maxStr := strings.Repeat("a", MaxPollOptionLength)
 		err := v.ValidatePollAttachment(&PollAttachment{

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,6 +1,7 @@
 package threads
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -366,15 +367,7 @@ func TestValidatePollAttachment(t *testing.T) {
 	})
 
 	t.Run("option A too long returns error", func(t *testing.T) {
-		longOption := string(make([]byte, MaxPollOptionLength+1))
-		for i := range []byte(longOption) {
-			longOption = longOption[:i] + "a" + longOption[i+1:]
-		}
-		// simpler approach:
-		longStr := ""
-		for i := 0; i < MaxPollOptionLength+1; i++ {
-			longStr += "a"
-		}
+		longStr := strings.Repeat("a", MaxPollOptionLength+1)
 		err := v.ValidatePollAttachment(&PollAttachment{
 			OptionA: longStr,
 			OptionB: "No",
@@ -388,10 +381,7 @@ func TestValidatePollAttachment(t *testing.T) {
 	})
 
 	t.Run("option C too long returns error", func(t *testing.T) {
-		longStr := ""
-		for i := 0; i < MaxPollOptionLength+1; i++ {
-			longStr += "a"
-		}
+		longStr := strings.Repeat("a", MaxPollOptionLength+1)
 		err := v.ValidatePollAttachment(&PollAttachment{
 			OptionA: "Yes",
 			OptionB: "No",
@@ -403,10 +393,7 @@ func TestValidatePollAttachment(t *testing.T) {
 	})
 
 	t.Run("option at max length is valid", func(t *testing.T) {
-		maxStr := ""
-		for i := 0; i < MaxPollOptionLength; i++ {
-			maxStr += "a"
-		}
+		maxStr := strings.Repeat("a", MaxPollOptionLength)
 		err := v.ValidatePollAttachment(&PollAttachment{
 			OptionA: maxStr,
 			OptionB: maxStr,
@@ -435,10 +422,7 @@ func TestValidateAltText(t *testing.T) {
 	})
 
 	t.Run("alt text at max length is valid", func(t *testing.T) {
-		maxStr := ""
-		for i := 0; i < MaxAltTextLength; i++ {
-			maxStr += "a"
-		}
+		maxStr := strings.Repeat("a", MaxAltTextLength)
 		err := v.ValidateAltText(maxStr)
 		if err != nil {
 			t.Errorf("Expected no error for max-length alt text, got: %v", err)
@@ -446,10 +430,7 @@ func TestValidateAltText(t *testing.T) {
 	})
 
 	t.Run("alt text too long returns error", func(t *testing.T) {
-		longStr := ""
-		for i := 0; i < MaxAltTextLength+1; i++ {
-			longStr += "a"
-		}
+		longStr := strings.Repeat("a", MaxAltTextLength+1)
 		err := v.ValidateAltText(longStr)
 		if err == nil {
 			t.Fatal("Expected error for alt text too long")
@@ -461,10 +442,7 @@ func TestValidateAltText(t *testing.T) {
 
 	t.Run("unicode characters counted correctly", func(t *testing.T) {
 		// Each Japanese character is 1 rune but 3 bytes; MaxAltTextLength runes should be valid
-		runeStr := ""
-		for i := 0; i < MaxAltTextLength; i++ {
-			runeStr += "あ"
-		}
+		runeStr := strings.Repeat("あ", MaxAltTextLength)
 		err := v.ValidateAltText(runeStr)
 		if err != nil {
 			t.Errorf("Expected no error for %d-rune alt text, got: %v", MaxAltTextLength, err)

--- a/validation_test.go
+++ b/validation_test.go
@@ -307,6 +307,225 @@ func TestValidateSearchOptions(t *testing.T) {
 	})
 }
 
+func TestValidatePollAttachment(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("nil is valid", func(t *testing.T) {
+		err := v.ValidatePollAttachment(nil)
+		if err != nil {
+			t.Errorf("Expected no error for nil, got: %v", err)
+		}
+	})
+
+	t.Run("valid two options", func(t *testing.T) {
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: "Yes",
+			OptionB: "No",
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("valid four options", func(t *testing.T) {
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: "Option A",
+			OptionB: "Option B",
+			OptionC: "Option C",
+			OptionD: "Option D",
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("missing option A returns error", func(t *testing.T) {
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: "",
+			OptionB: "No",
+		})
+		if err == nil {
+			t.Fatal("Expected error for missing option A")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("missing option B returns error", func(t *testing.T) {
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: "Yes",
+			OptionB: "",
+		})
+		if err == nil {
+			t.Fatal("Expected error for missing option B")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("option A too long returns error", func(t *testing.T) {
+		longOption := string(make([]byte, MaxPollOptionLength+1))
+		for i := range []byte(longOption) {
+			longOption = longOption[:i] + "a" + longOption[i+1:]
+		}
+		// simpler approach:
+		longStr := ""
+		for i := 0; i < MaxPollOptionLength+1; i++ {
+			longStr += "a"
+		}
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: longStr,
+			OptionB: "No",
+		})
+		if err == nil {
+			t.Fatal("Expected error for option A too long")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("option C too long returns error", func(t *testing.T) {
+		longStr := ""
+		for i := 0; i < MaxPollOptionLength+1; i++ {
+			longStr += "a"
+		}
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: "Yes",
+			OptionB: "No",
+			OptionC: longStr,
+		})
+		if err == nil {
+			t.Fatal("Expected error for option C too long")
+		}
+	})
+
+	t.Run("option at max length is valid", func(t *testing.T) {
+		maxStr := ""
+		for i := 0; i < MaxPollOptionLength; i++ {
+			maxStr += "a"
+		}
+		err := v.ValidatePollAttachment(&PollAttachment{
+			OptionA: maxStr,
+			OptionB: maxStr,
+		})
+		if err != nil {
+			t.Errorf("Expected no error for max-length options, got: %v", err)
+		}
+	})
+}
+
+func TestValidateAltText(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("empty is valid", func(t *testing.T) {
+		err := v.ValidateAltText("")
+		if err != nil {
+			t.Errorf("Expected no error for empty alt text, got: %v", err)
+		}
+	})
+
+	t.Run("valid alt text", func(t *testing.T) {
+		err := v.ValidateAltText("A beautiful sunset over the ocean")
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("alt text at max length is valid", func(t *testing.T) {
+		maxStr := ""
+		for i := 0; i < MaxAltTextLength; i++ {
+			maxStr += "a"
+		}
+		err := v.ValidateAltText(maxStr)
+		if err != nil {
+			t.Errorf("Expected no error for max-length alt text, got: %v", err)
+		}
+	})
+
+	t.Run("alt text too long returns error", func(t *testing.T) {
+		longStr := ""
+		for i := 0; i < MaxAltTextLength+1; i++ {
+			longStr += "a"
+		}
+		err := v.ValidateAltText(longStr)
+		if err == nil {
+			t.Fatal("Expected error for alt text too long")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("unicode characters counted correctly", func(t *testing.T) {
+		// Each Japanese character is 1 rune but 3 bytes; MaxAltTextLength runes should be valid
+		runeStr := ""
+		for i := 0; i < MaxAltTextLength; i++ {
+			runeStr += "あ"
+		}
+		err := v.ValidateAltText(runeStr)
+		if err != nil {
+			t.Errorf("Expected no error for %d-rune alt text, got: %v", MaxAltTextLength, err)
+		}
+	})
+}
+
+func TestValidateTextStylingValues(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("valid bold style", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 5, StylingInfo: []string{"bold"}},
+		})
+		if err != nil {
+			t.Errorf("Expected no error for bold style, got: %v", err)
+		}
+	})
+
+	t.Run("valid all styles", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 5, StylingInfo: []string{"bold", "italic"}},
+			{Offset: 10, Length: 5, StylingInfo: []string{"highlight"}},
+			{Offset: 20, Length: 5, StylingInfo: []string{"underline", "strikethrough"}},
+		})
+		if err != nil {
+			t.Errorf("Expected no error for valid styles, got: %v", err)
+		}
+	})
+
+	t.Run("invalid style value returns error", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 5, StylingInfo: []string{"bold", "superscript"}},
+		})
+		if err == nil {
+			t.Fatal("Expected error for invalid style value 'superscript'")
+		}
+		if !IsValidationError(err) {
+			t.Errorf("Expected ValidationError, got %T", err)
+		}
+	})
+
+	t.Run("empty style slice is valid", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 5, StylingInfo: []string{}},
+		})
+		if err != nil {
+			t.Errorf("Expected no error for empty style slice, got: %v", err)
+		}
+	})
+
+	t.Run("unknown style returns error", func(t *testing.T) {
+		err := v.validateTextStylingRanges([]TextStylingInfo{
+			{Offset: 0, Length: 5, StylingInfo: []string{"BOLD"}}, // uppercase is invalid
+		})
+		if err == nil {
+			t.Fatal("Expected error for uppercase style value")
+		}
+	})
+}
+
 func TestConfigValidatorValidateRequiredFields(t *testing.T) {
 	cv := NewConfigValidator()
 


### PR DESCRIPTION
## Summary

Comprehensive audit of the threads-go client against the official Meta Threads API documentation, fixing all Critical, Major, and Minor discrepancies found across 16 API domains.

- Add missing response fields to `Post` struct and `PostExtendedFields` (root cause for many fields never being returned)
- Add `GetAppAccessToken` and `GetAppAccessTokenShorthand` for app-level auth (e.g., oEmbed)
- Add typed `ReplyAudience` and `HideStatus` constants for response values (distinct from creation-side `ReplyControl`)
- Add response media type constants (`TEXT_POST`, `CAROUSEL_ALBUM`, `AUDIO`, `REPOST_FACADE`)
- Add input validation for polls, alt text, and text styling values
- Add container error message constants, geo-gating error codes
- Fix `recently_searched_keywords` type and field mapping on `User` struct
- Fix `GetUserMentions` to support `since`/`until` filtering
- Fix `DeletePost` to return `deleted_id` from API response
- Fix `Post.TextEntities` to handle API response wrapper format (`{"data": [...]}`)
- Add `GetUserGhostPosts` to `PostReader` interface; guard ghost post on non-text containers
- Add `LinkURL` to `TotalValue` for click metric insights
- Document rate limits, formulas, and in-development metric status

## Breaking changes

This release includes source-incompatible changes to exported interfaces:

- **`PostReader.GetUserMentions`**: signature changed from `(*PaginationOptions)` to `(*PostsOptions)` to support `since`/`until` filtering
- **`PostDeleter.DeletePost`**: return type changed from `error` to `(string, error)` to expose `deleted_id`
- **`Post.ReplyAudience`**: type changed from `string` to `ReplyAudience`
- **`Post.HideStatus`**: type changed from `string` to `HideStatus`
- **`Post.TextEntities`**: type changed from `[]TextEntity` to `*TextEntitiesResponse`

Downstream code implementing these interfaces or reading these fields will need updates.

## Version: 1.8.0

The jump from 1.1.0 to 1.8.0 is intentional — the `Version` constant was stale and out of sync with the release tags (latest release is v1.7.1). This aligns the constant with the next release.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean
- [x] Integration tests with live token