### PR TITLE
fix(auth): DebugToken must call Meta with app access token

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -469,12 +469,25 @@ func (c *Client) DebugToken(ctx context.Context, inputToken string) (*DebugToken
 		inputToken = accessToken
 	}
 
-	params := url.Values{
-		"input_token":  {inputToken},
-		"access_token": {accessToken},
+	// Meta's /debug_token expects an app access token (TH|<APP_ID>|<APP_SECRET>)
+	// as the caller. For apps in Development mode, passing a user token here
+	// fails with error code 100 ("The app associated with this request is in
+	// dev mode") even when the user has a role on the app, because Meta
+	// resolves the request's app context from the caller token and enforces
+	// dev-mode role checks against that. Fall back to the user token only if
+	// ClientID/ClientSecret aren't configured, to preserve behavior for
+	// callers that don't supply them.
+	callerToken := c.GetAppAccessTokenShorthand()
+	if callerToken == "" {
+		callerToken = accessToken
 	}
 
-	resp, err := c.httpClient.GET("/debug_token", params, accessToken)
+	params := url.Values{
+		"input_token":  {inputToken},
+		"access_token": {callerToken},
+	}
+
+	resp, err := c.httpClient.GET("/debug_token", params, callerToken)
 	if err != nil {
 		return nil, NewNetworkError(0, "Failed to debug token", err.Error(), true)
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -177,19 +177,34 @@ func TestRefreshToken_NoToken(t *testing.T) {
 }
 
 func TestDebugToken_Success(t *testing.T) {
-	client := testClient(t, jsonHandler(200, `{
-		"data": {
-			"type": "USER",
-			"application": "Test App",
-			"is_valid": true,
-			"expires_at": 1735689600,
-			"issued_at": 1735603200,
-			"user_id": "12345",
-			"scopes": ["threads_basic"]
-		}
-	}`))
+	const wantAppToken = "TH|test-client-id|test-client-secret"
+	const wantInputToken = "test-token"
 
-	resp, err := client.DebugToken(context.Background(), "test-token")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("access_token"); got != wantAppToken {
+			t.Errorf("access_token: got %q, want %q (app-token shorthand required by Meta's /debug_token)", got, wantAppToken)
+		}
+		if got := r.URL.Query().Get("input_token"); got != wantInputToken {
+			t.Errorf("input_token: got %q, want %q", got, wantInputToken)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"type": "USER",
+				"application": "Test App",
+				"is_valid": true,
+				"expires_at": 1735689600,
+				"issued_at": 1735603200,
+				"user_id": "12345",
+				"scopes": ["threads_basic"]
+			}
+		}`))
+	})
+
+	client := testClient(t, handler)
+
+	resp, err := client.DebugToken(context.Background(), wantInputToken)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -198,6 +213,31 @@ func TestDebugToken_Success(t *testing.T) {
 	}
 	if resp.Data.UserID != "12345" {
 		t.Errorf("expected user ID 12345, got %s", resp.Data.UserID)
+	}
+}
+
+// When ClientID/ClientSecret are not configured, DebugToken must fall back to
+// the user access token as the caller. Covers the no-app-creds branch.
+func TestDebugToken_FallbackToUserTokenWithoutClientCreds(t *testing.T) {
+	const wantCallerToken = "test-access-token"
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("access_token"); got != wantCallerToken {
+			t.Errorf("access_token: got %q, want %q (must fall back to user token when no app creds)", got, wantCallerToken)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":{"type":"USER","is_valid":true,"expires_at":1735689600,"issued_at":1735603200,"user_id":"12345","scopes":["threads_basic"]}}`))
+	})
+
+	client := testClient(t, handler)
+	// NewClient rejects empty client creds, so blank them out post-construction
+	// to exercise the fallback branch in DebugToken.
+	client.config.ClientID = ""
+	client.config.ClientSecret = ""
+
+	if _, err := client.DebugToken(context.Background(), ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `DebugToken` was passing the user access token as the `access_token` parameter on `/debug_token`. Per Meta, that endpoint expects an app access token, and for apps in **Development mode** the user-token path is rejected with error code 100 (\"The app associated with this request is in dev mode\") — even when the user has a role on the app (a Threads-only role isn't enough for the platform-level dev-mode gate).
- Now uses `GetAppAccessTokenShorthand()` (`TH|<APP_ID>|<APP_SECRET>`) as the caller when `ClientID`/`ClientSecret` are configured, falling back to the user token to preserve behavior for callers that don't supply app credentials.

## Reproduction

Hit by the `fia-f1-docs-bot` service: a dev-mode app with a valid user token (Threads Tester role) failed on every startup at `NewClientWithToken` → `DebugToken`. The Meta Access Token Debugger UI showed the same token as valid, because that path authenticates as the logged-in app admin rather than the token's user.