### PR TITLE
fix: NewClientWithToken /me fallback + non-retryable auth errors

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -489,7 +489,11 @@ func (c *Client) DebugToken(ctx context.Context, inputToken string) (*DebugToken
 
 	resp, err := c.httpClient.GET("/debug_token", params, callerToken)
 	if err != nil {
-		return nil, NewNetworkError(0, "Failed to debug token", err.Error(), true)
+		// Propagate the typed error (e.g. AuthenticationError for code 190)
+		// so callers can inspect it correctly. Wrapping in a NetworkError with
+		// temporary=true was wrong: it hid the real type and made auth errors
+		// appear retryable.
+		return nil, fmt.Errorf("Failed to debug token - %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/client.go
+++ b/client.go
@@ -538,17 +538,20 @@ func NewClientWithToken(accessToken string, config *Config) (*Client, error) {
 		return client, nil
 	}
 
-	// debug_token failed — verify with /me as fallback
-	meResp, err := client.TestAPICall("GET", "/v1.0/me", map[string]string{"fields": "id"})
-	if err != nil {
-		// Both validation paths failed; surface the original debug_token error
-		return nil, fmt.Errorf("failed to validate token: %w", debugErr)
+	// debug_token failed — verify with /me as fallback. Call httpClient
+	// directly rather than TestAPICall (which is test-only infrastructure).
+	meResp, meErr := client.httpClient.GET("/v1.0/me", url.Values{"fields": {"id"}}, accessToken)
+	if meErr != nil {
+		return nil, fmt.Errorf("failed to validate token (debug_token: %v, /me: %w)", debugErr, meErr)
 	}
 
 	var me struct {
 		ID string `json:"id"`
 	}
-	if jsonErr := json.Unmarshal(meResp.Body, &me); jsonErr != nil || me.ID == "" {
+	if jsonErr := json.Unmarshal(meResp.Body, &me); jsonErr != nil {
+		return nil, fmt.Errorf("failed to parse /me response (debug_token also failed: %v): %w", debugErr, jsonErr)
+	}
+	if me.ID == "" {
 		return nil, fmt.Errorf("failed to validate token: %w", debugErr)
 	}
 

--- a/client.go
+++ b/client.go
@@ -526,14 +526,41 @@ func NewClientWithToken(accessToken string, config *Config) (*Client, error) {
 		return nil, fmt.Errorf("failed to set temporary token: %w", err)
 	}
 
-	// Validate and get accurate token information
-	debugResp, err := client.DebugToken(context.Background(), accessToken)
-	if err != nil {
-		return nil, fmt.Errorf("failed to validate token: %w", err)
+	// Validate and get accurate token information via debug_token. If that
+	// endpoint fails (graph.threads.net returns HTTP 500 for valid tokens on
+	// dev-mode apps), fall back to a /me call which reliably validates the
+	// token and returns the user ID needed to bootstrap TokenInfo.
+	debugResp, debugErr := client.DebugToken(context.Background(), accessToken)
+	if debugErr == nil {
+		if err := client.SetTokenFromDebugInfo(accessToken, debugResp); err != nil {
+			return nil, fmt.Errorf("failed to set token info: %w", err)
+		}
+		return client, nil
 	}
 
-	// Set accurate token information from debug response
-	if err := client.SetTokenFromDebugInfo(accessToken, debugResp); err != nil {
+	// debug_token failed — verify with /me as fallback
+	meResp, err := client.TestAPICall("GET", "/v1.0/me", map[string]string{"fields": "id"})
+	if err != nil {
+		// Both validation paths failed; surface the original debug_token error
+		return nil, fmt.Errorf("failed to validate token: %w", debugErr)
+	}
+
+	var me struct {
+		ID string `json:"id"`
+	}
+	if jsonErr := json.Unmarshal(meResp.Body, &me); jsonErr != nil || me.ID == "" {
+		return nil, fmt.Errorf("failed to validate token: %w", debugErr)
+	}
+
+	// /me succeeded — token is valid. Set token info with the user ID and a
+	// 60-day expiry (standard Threads long-lived token lifetime).
+	if err := client.SetTokenInfo(&TokenInfo{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(60 * 24 * time.Hour),
+		UserID:      me.ID,
+		CreatedAt:   time.Now(),
+	}); err != nil {
 		return nil, fmt.Errorf("failed to set token info: %w", err)
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -1235,6 +1235,41 @@ func TestNewClientWithToken(t *testing.T) {
 		}
 	})
 
+	t.Run("debug_token 500 falls back to /me", func(t *testing.T) {
+		// graph.threads.net returns HTTP 500 for valid tokens on dev-mode apps;
+		// NewClientWithToken must fall back to /me and succeed.
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/debug_token" {
+				w.WriteHeader(500)
+				w.Write([]byte(`{"error":{"message":"Invalid OAuth 2.0 Access Token","code":190,"type":"THApiException","error_data":[]}}`))
+				return
+			}
+			// /v1.0/me fallback
+			w.WriteHeader(200)
+			w.Write([]byte(`{"id":"27258452443753298","username":"fiadocs"}`))
+		}))
+		defer ts.Close()
+
+		config := &Config{
+			ClientID:     "test-id",
+			ClientSecret: "test-secret",
+			RedirectURI:  "https://example.com/callback",
+			BaseURL:      ts.URL,
+		}
+
+		client, err := NewClientWithToken("valid-token", config)
+		if err != nil {
+			t.Fatalf("expected no error when /me succeeds, got: %v", err)
+		}
+		if !client.IsAuthenticated() {
+			t.Error("expected client to be authenticated")
+		}
+		if client.GetTokenInfo().UserID != "27258452443753298" {
+			t.Errorf("expected UserID 27258452443753298, got %s", client.GetTokenInfo().UserID)
+		}
+	})
+
 	t.Run("valid token with mock server", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/http_client.go
+++ b/http_client.go
@@ -315,8 +315,15 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 		details = details[:500] + "..."
 	}
 
-	// Create specific error types based on status code
+	// API-level auth codes take priority over HTTP status. Meta returns 5xx
+	// for token failures on some endpoints (e.g. /debug_token returns HTTP 500
+	// for error 190), which would otherwise be misclassified as retryable 5xx.
 	var resultErr error
+	if isAuthErrorCode(errorCode) {
+		authErr := NewAuthenticationError(errorCode, message, details)
+		setErrorMetadata(authErr, false, resp.StatusCode, apiErr.Error.ErrorSubcode)
+		return authErr
+	}
 	switch resp.StatusCode {
 	case 401, 403:
 		resultErr = NewAuthenticationError(errorCode, message, details)
@@ -351,6 +358,20 @@ func (h *HTTPClient) createErrorFromResponse(resp *Response) error {
 	setErrorMetadata(resultErr, isTransient, resp.StatusCode, apiErr.Error.ErrorSubcode)
 
 	return resultErr
+}
+
+// isAuthErrorCode reports whether code is a well-known Meta/Threads top-level
+// auth error that should always map to AuthenticationError, regardless of HTTP
+// status. Meta returns 5xx for these on some endpoints (e.g. /debug_token).
+// Subcodes (463 = token expired, 467 = missing permissions) nest under 190
+// and are handled by the caller via setErrorMetadata.
+func isAuthErrorCode(code int) bool {
+	switch code {
+	case 190, // Invalid/revoked/expired access token (subcodes 463, 467)
+		102: // Session invalidated / login required
+		return true
+	}
+	return false
 }
 
 // wrapNetworkError wraps network errors with appropriate error types.

--- a/http_client.go
+++ b/http_client.go
@@ -394,6 +394,15 @@ func (h *HTTPClient) wrapNetworkError(err error) error {
 
 // isRetryableError determines if an error should trigger a retry
 func (h *HTTPClient) isRetryableError(err error) bool {
+	// Authentication errors are never retryable — the token is invalid and
+	// no amount of retrying will fix it. Guard this before the status-code
+	// check below: setErrorMetadata stores the HTTP status (e.g. 500 from
+	// graph.threads.net) on AuthenticationError's embedded BaseError, so the
+	// HTTPStatusCode >= 500 branch would otherwise re-enable retries.
+	if IsAuthenticationError(err) {
+		return false
+	}
+
 	// Rate limit errors are retry-able
 	if IsRateLimitError(err) {
 		return true


### PR DESCRIPTION
## Summary

Fixes startup failure on dev-mode Threads apps caused by `graph.threads.net/debug_token` returning HTTP 500 for valid tokens.

- **`NewClientWithToken` /me fallback** (`client.go`): if `DebugToken` fails, fall back to `GET /v1.0/me?fields=id` to verify the token works for real API calls. Only surface the `DebugToken` error if `/me` also fails. On /me success, bootstraps `TokenInfo` with the user ID and a 60-day expiry.
- **Auth error codes are non-retryable** (`http_client.go`): `createErrorFromResponse` now checks known top-level auth codes (190, 102) before the HTTP-status switch. A 5xx response carrying code 190 previously fell through to `NewAPIError` with `HTTPStatusCode=500`, which `isRetryableError` treated as retryable — causing 3 retries and a ~7s delay before the /me fallback even ran.
- **`DebugToken` error wrapping fixed** (`auth.go`): was wrapping all errors in `NewNetworkError(code=0, temporary=true)`, hiding the real typed error and marking non-transient auth failures as retryable. Now uses `fmt.Errorf` to preserve the underlying type.

## Verification

Tested end-to-end against a live Threads dev-mode app: `NewClientWithToken` now initialises in <1s (previously 7s+ from retries, then hard failure) and correctly uses the user ID from `/me` to set `TokenInfo`.