### PR TITLE
Recover from /threads_publish HTTP 5xx + code 10 false-failures

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -719,6 +719,33 @@ func TestIsRetryableErrorWithTransientAPIError(t *testing.T) {
 	}
 }
 
+func TestIsRetryableError_Code10NotRetried(t *testing.T) {
+	// Meta returns HTTP 5xx from /threads_publish for some app/permission
+	// configurations with error code 10 (GraphMethodException). Without an
+	// explicit non-retryable override, the 5xx branch of isRetryableError
+	// would retry it — burning publishing quota for every cycle. Verify the
+	// override holds.
+	h := &HTTPClient{
+		logger:      &noopLogger{},
+		retryConfig: &RetryConfig{MaxRetries: 3, InitialDelay: time.Second, MaxDelay: time.Second, BackoffFactor: 2},
+	}
+
+	apiErr := NewAPIError(10, "Application does not have permission for this action", "details", "trace")
+	apiErr.HTTPStatusCode = 500
+
+	if h.isRetryableError(apiErr) {
+		t.Error("expected code 10 with HTTP 500 to be non-retryable; would burn publishing quota otherwise")
+	}
+
+	// Sanity: a different 5xx code should still retry, so we're not
+	// over-broadening the non-retryable list.
+	other5xx := NewAPIError(2, "Unexpected error", "details", "trace")
+	other5xx.HTTPStatusCode = 500
+	if !h.isRetryableError(other5xx) {
+		t.Error("expected a non-listed 5xx code to remain retryable")
+	}
+}
+
 func TestIsTransientErrorHelper(t *testing.T) {
 	transientErr := NewAPIError(2, "Unexpected error", "details", "trace")
 	transientErr.IsTransient = true

--- a/http_client.go
+++ b/http_client.go
@@ -374,6 +374,28 @@ func isAuthErrorCode(code int) bool {
 	return false
 }
 
+// isNonRetryablePermanentErrorCode reports whether the given Meta error code
+// is a permanent failure that won't be fixed by retrying. Meta returns HTTP
+// 5xx for these on some endpoints (notably /threads_publish), which would
+// otherwise be misclassified as a transient 5xx and retried — wasting API
+// quota that's counted per attempt.
+//
+// Auth codes (190, 102) are deliberately not listed here; they go through the
+// IsAuthenticationError() short-circuit at the top of isRetryableError.
+func isNonRetryablePermanentErrorCode(code int) bool {
+	switch code {
+	case 10:
+		// GraphMethodException — "Application does not have permission for
+		// this action". Meta returns this from /threads_publish for some
+		// app/permission configurations; per the API troubleshooting docs
+		// the publish may actually have succeeded even when this is
+		// returned, so callers can recover by checking container status.
+		// Retrying the publish never helps and burns publishing quota.
+		return true
+	}
+	return false
+}
+
 // wrapNetworkError wraps network errors with appropriate error types.
 // The original error is preserved as the Cause, so errors.Is/errors.As
 // can inspect it (e.g., to detect context.Canceled).
@@ -417,6 +439,12 @@ func (h *HTTPClient) isRetryableError(err error) bool {
 	// Check base error for transient flag or 5xx HTTP status
 	baseErr := extractBaseError(err)
 	if baseErr != nil {
+		// Permanent error codes short-circuit the 5xx branch below. Meta
+		// returns 5xx for some non-transient API codes (e.g. code 10 from
+		// /threads_publish); without this check we'd retry and burn quota.
+		if isNonRetryablePermanentErrorCode(baseErr.Code) {
+			return false
+		}
 		if baseErr.IsTransient {
 			return true
 		}

--- a/posts_create.go
+++ b/posts_create.go
@@ -43,8 +43,12 @@ func (c *Client) CreateTextPost(ctx context.Context, content *TextPostContent) (
 	}
 
 	// Publish the container
+	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
+		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeTextMatcher(content)); recErr == nil {
+			return recovered, nil
+		}
 		return nil, fmt.Errorf("failed to publish text post: %w", err)
 	}
 
@@ -79,8 +83,12 @@ func (c *Client) CreateImagePost(ctx context.Context, content *ImagePostContent)
 	}
 
 	// Publish the container
+	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
+		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeImageMatcher(content)); recErr == nil {
+			return recovered, nil
+		}
 		return nil, fmt.Errorf("failed to publish image post: %w", err)
 	}
 
@@ -115,8 +123,12 @@ func (c *Client) CreateVideoPost(ctx context.Context, content *VideoPostContent)
 	}
 
 	// Publish the container
+	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
+		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeVideoMatcher(content)); recErr == nil {
+			return recovered, nil
+		}
 		return nil, fmt.Errorf("failed to publish video post: %w", err)
 	}
 
@@ -191,8 +203,12 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 	}
 
 	// Publish the container
+	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
+		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeCarouselMatcher(content.Children)); recErr == nil {
+			return recovered, nil
+		}
 		return nil, fmt.Errorf("failed to publish carousel post: %w", err)
 	}
 

--- a/posts_publish_recovery.go
+++ b/posts_publish_recovery.go
@@ -152,46 +152,73 @@ func makeCarouselMatcher(childContainerIDs []string) publishMatcher {
 }
 
 // makeImageMatcher returns a matcher for a single-image post. For replies,
-// match strictly by parent post ID (which is unique within the recovery
-// window for posts from this user). For non-replies, match by exact text +
-// media type + non-reply state. The image URL stored on the post is Meta's
-// CDN URL, not ours, so we don't compare it.
+// parent ID alone is not unique — a caller can legitimately publish multiple
+// replies to the same parent, and clock skew or propagation delay could put
+// a prior reply inside the recovery window. So for replies we additionally
+// require exact text equality or a matching quoted-post target; blank-text
+// non-quote replies fail closed because they have no unique signal. For
+// non-replies, exact text + non-reply state is the disambiguator. The image
+// URL stored on the post is Meta's CDN URL, not ours, so we don't compare it.
 func makeImageMatcher(content *ImagePostContent) publishMatcher {
 	return func(p *Post) bool {
 		if p.MediaType != MediaTypeImage {
 			return false
 		}
-		if content.ReplyTo != "" {
-			return p.IsReply && repliedToID(p) == content.ReplyTo
+		if !quoteMatches(p, content.QuotedPostID) {
+			return false
 		}
-		return !p.IsReply && p.Text == content.Text
+		if content.ReplyTo == "" {
+			return !p.IsReply && p.Text == content.Text
+		}
+		if !p.IsReply || repliedToID(p) != content.ReplyTo {
+			return false
+		}
+		if !replyHasUniqueDiscriminator(content.Text, content.QuotedPostID) {
+			return false
+		}
+		return p.Text == content.Text
 	}
 }
 
 // makeVideoMatcher mirrors makeImageMatcher for video posts. After publish,
 // Meta may report video posts as media_type == "VIDEO" or "AUDIO" (for
-// audio-only uploads). Accept either.
+// audio-only uploads). Accept either. The same reply-uniqueness rules apply:
+// blank-text non-quote replies fail closed.
 func makeVideoMatcher(content *VideoPostContent) publishMatcher {
 	return func(p *Post) bool {
 		if p.MediaType != MediaTypeVideo && p.MediaType != MediaTypeAudio {
 			return false
 		}
-		if content.ReplyTo != "" {
-			return p.IsReply && repliedToID(p) == content.ReplyTo
+		if !quoteMatches(p, content.QuotedPostID) {
+			return false
 		}
-		return !p.IsReply && p.Text == content.Text
+		if content.ReplyTo == "" {
+			return !p.IsReply && p.Text == content.Text
+		}
+		if !p.IsReply || repliedToID(p) != content.ReplyTo {
+			return false
+		}
+		if !replyHasUniqueDiscriminator(content.Text, content.QuotedPostID) {
+			return false
+		}
+		return p.Text == content.Text
 	}
 }
 
-// makeTextMatcher returns a matcher for a text-only post. Replies match by
-// parent ID + text. Non-replies match by text + topic tag (the topic tag
-// disambiguates same-text posts across different topics).
+// makeTextMatcher returns a matcher for a text-only post. Text posts always
+// have non-empty text (validated upstream), so text equality is itself a
+// strong discriminator. Quote state must match in both directions, and
+// non-replies additionally compare topic_tag to disambiguate same-text posts
+// across different topics.
 func makeTextMatcher(content *TextPostContent) publishMatcher {
 	wantTextType := MediaTypeResponseText
 	return func(p *Post) bool {
-		// Some text post variants may come back as TEXT_POST or omit
-		// media_type entirely. Accept both shapes.
+		// Some text post variants come back as TEXT_POST or omit media_type
+		// entirely. Accept both shapes.
 		if p.MediaType != "" && p.MediaType != wantTextType && p.MediaType != MediaTypeText {
+			return false
+		}
+		if !quoteMatches(p, content.QuotedPostID) {
 			return false
 		}
 		if p.Text != content.Text {
@@ -202,6 +229,28 @@ func makeTextMatcher(content *TextPostContent) publishMatcher {
 		}
 		return !p.IsReply && p.TopicTag == content.TopicTag
 	}
+}
+
+// quoteMatches reports whether a retrieved post's quote state aligns with
+// what the caller asked for. wantQuotedID == "" means "must not be a quote
+// post"; non-empty means "must be a quote of that specific post". Matching
+// across the quote/non-quote boundary would let a regular post masquerade as
+// a quote post (or vice-versa) during recovery.
+func quoteMatches(p *Post, wantQuotedID string) bool {
+	if wantQuotedID == "" {
+		return !p.IsQuotePost
+	}
+	if !p.IsQuotePost || p.QuotedPost == nil {
+		return false
+	}
+	return p.QuotedPost.ID == wantQuotedID
+}
+
+// replyHasUniqueDiscriminator reports whether the (text, quotedPostID) pair
+// is strong enough to single out one reply among potentially many to the
+// same parent. Without one of these signals we'd be guessing.
+func replyHasUniqueDiscriminator(text, quotedPostID string) bool {
+	return text != "" || quotedPostID != ""
 }
 
 // repliedToID returns the parent post ID for a reply, preferring the

--- a/posts_publish_recovery.go
+++ b/posts_publish_recovery.go
@@ -157,8 +157,10 @@ func makeCarouselMatcher(childContainerIDs []string) publishMatcher {
 // a prior reply inside the recovery window. So for replies we additionally
 // require exact text equality or a matching quoted-post target; blank-text
 // non-quote replies fail closed because they have no unique signal. For
-// non-replies, exact text + non-reply state is the disambiguator. The image
-// URL stored on the post is Meta's CDN URL, not ours, so we don't compare it.
+// non-replies, exact text + topic_tag + non-reply state is the disambiguator
+// — topic_tag breaks ties between same-text posts across different topics,
+// matching makeTextMatcher's behavior. The image URL stored on the post is
+// Meta's CDN URL, not ours, so we don't compare it.
 func makeImageMatcher(content *ImagePostContent) publishMatcher {
 	return func(p *Post) bool {
 		if p.MediaType != MediaTypeImage {
@@ -168,7 +170,7 @@ func makeImageMatcher(content *ImagePostContent) publishMatcher {
 			return false
 		}
 		if content.ReplyTo == "" {
-			return !p.IsReply && p.Text == content.Text
+			return !p.IsReply && p.Text == content.Text && p.TopicTag == content.TopicTag
 		}
 		if !p.IsReply || repliedToID(p) != content.ReplyTo {
 			return false
@@ -183,7 +185,8 @@ func makeImageMatcher(content *ImagePostContent) publishMatcher {
 // makeVideoMatcher mirrors makeImageMatcher for video posts. After publish,
 // Meta may report video posts as media_type == "VIDEO" or "AUDIO" (for
 // audio-only uploads). Accept either. The same reply-uniqueness rules apply:
-// blank-text non-quote replies fail closed.
+// blank-text non-quote replies fail closed. Non-replies disambiguate on
+// text + topic_tag.
 func makeVideoMatcher(content *VideoPostContent) publishMatcher {
 	return func(p *Post) bool {
 		if p.MediaType != MediaTypeVideo && p.MediaType != MediaTypeAudio {
@@ -193,7 +196,7 @@ func makeVideoMatcher(content *VideoPostContent) publishMatcher {
 			return false
 		}
 		if content.ReplyTo == "" {
-			return !p.IsReply && p.Text == content.Text
+			return !p.IsReply && p.Text == content.Text && p.TopicTag == content.TopicTag
 		}
 		if !p.IsReply || repliedToID(p) != content.ReplyTo {
 			return false

--- a/posts_publish_recovery.go
+++ b/posts_publish_recovery.go
@@ -1,0 +1,218 @@
+package threads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// publishRecoveryWindow is the negative buffer applied to the publishStart
+// timestamp when querying recent posts during recovery. It absorbs clock skew
+// between the local machine and Meta's servers without widening the search
+// enough to risk collisions with prior unrelated publishes.
+const publishRecoveryWindow = 5 * time.Second
+
+// errPublishNotRecovered is the sentinel returned by tryRecoverPublishedPost
+// when no recovery is possible. Callers should surface the original publish
+// error in this case, not the recovery error.
+var errPublishNotRecovered = errors.New("publish not recovered")
+
+// publishMatcher reports whether a post returned from /me/threads is the
+// post that the current publish attempt produced. Matchers are content-type
+// specific (carousel matches by child container IDs, image-reply matches by
+// reply_to, etc.); see makeXxxMatcher helpers below.
+type publishMatcher func(*Post) bool
+
+// shouldAttemptPublishRecovery reports whether err matches the documented
+// Meta pattern where /threads_publish returns an error response despite the
+// container actually being published. Currently this is code 10
+// (GraphMethodException — "Application does not have permission for this
+// action"), which Meta returns from /threads_publish for some app/permission
+// configurations after-the-fact, with the container moving to PUBLISHED
+// regardless. See the Threads API troubleshooting docs (section "Publishing
+// Does Not Return a Media ID") for the canonical recovery strategy.
+func shouldAttemptPublishRecovery(err error) bool {
+	base := extractBaseError(err)
+	if base == nil {
+		return false
+	}
+	return isNonRetryablePermanentErrorCode(base.Code)
+}
+
+// recoverFromPublishError is the single entry point Create*Post functions
+// call after a failed publishContainer. It short-circuits to errPublishNotRecovered
+// when the publish error is not one we know to be ambiguous (i.e. not
+// code 10), avoiding an extra Meta round-trip for genuine failures.
+func (c *Client) recoverFromPublishError(
+	ctx context.Context,
+	containerID string,
+	publishStart time.Time,
+	publishErr error,
+	match publishMatcher,
+) (*Post, error) {
+	if !shouldAttemptPublishRecovery(publishErr) {
+		return nil, errPublishNotRecovered
+	}
+	return c.tryRecoverPublishedPost(ctx, containerID, publishStart, match)
+}
+
+// tryRecoverPublishedPost implements the Meta-documented recovery flow for
+// /threads_publish calls that error out despite succeeding server-side:
+//
+//  1. Confirm the container's status is PUBLISHED (cheap, single GET). If it
+//     isn't, the publish really did fail and there's nothing to recover.
+//  2. List recent posts authored by this user since publishStart (minus a
+//     small skew buffer) and apply the caller-supplied matcher.
+//  3. Return the unique matching post, or errPublishNotRecovered if zero or
+//     more than one posts match.
+//
+// The matcher MUST be content-specific enough to be unique per request even
+// under concurrent publishes from the same user. For carousels, that's the
+// set of child container IDs (Meta mints fresh IDs per CreateMediaContainer
+// call, so two concurrent carousels never share children). For other post
+// types, see the corresponding makeXxxMatcher helper.
+//
+// The function intentionally returns errPublishNotRecovered (not the original
+// publish error) when recovery isn't possible — the caller is expected to
+// propagate the original error in that case.
+func (c *Client) tryRecoverPublishedPost(
+	ctx context.Context,
+	containerID string,
+	publishStart time.Time,
+	match publishMatcher,
+) (*Post, error) {
+	// Gate 1: container must be in PUBLISHED state. This is the canonical
+	// signal from Meta that the publish actually succeeded.
+	status, err := c.GetContainerStatus(ctx, ContainerID(containerID))
+	if err != nil {
+		return nil, fmt.Errorf("recovery: failed to fetch container status: %w", err)
+	}
+	if status.Status != ContainerStatusPublished {
+		return nil, errPublishNotRecovered
+	}
+
+	// Gate 2: a matching post must exist in the user's recent timeline,
+	// posted after we started the publish attempt.
+	userID := c.getUserID()
+	if userID == "" {
+		return nil, NewAuthenticationError(401, "User ID not available", "Cannot determine user ID from token")
+	}
+	sinceTS := publishStart.Add(-publishRecoveryWindow).Unix()
+	posts, err := c.GetUserPostsWithOptions(ctx, UserID(userID), &PostsOptions{
+		Limit: 25,
+		Since: sinceTS,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("recovery: failed to list recent posts: %w", err)
+	}
+
+	// Find a unique match. Fail closed on multiple matches — the matcher
+	// is supposed to be unique per request, so >1 match means something
+	// is off and we'd rather surface the original error than return the
+	// wrong post.
+	var found *Post
+	for i := range posts.Data {
+		if match(&posts.Data[i]) {
+			if found != nil {
+				return nil, errPublishNotRecovered
+			}
+			found = &posts.Data[i]
+		}
+	}
+	if found == nil {
+		return nil, errPublishNotRecovered
+	}
+	return found, nil
+}
+
+// makeCarouselMatcher returns a matcher that identifies the published
+// carousel post by exact equality of its child container ID set. Carousel
+// child container IDs are minted per CreateMediaContainer call and are
+// globally unique, so this is collision-proof across concurrent publishes.
+func makeCarouselMatcher(childContainerIDs []string) publishMatcher {
+	expected := make(map[string]struct{}, len(childContainerIDs))
+	for _, id := range childContainerIDs {
+		expected[id] = struct{}{}
+	}
+	return func(p *Post) bool {
+		if p.MediaType != MediaTypeResponseCarousel {
+			return false
+		}
+		if p.Children == nil || len(p.Children.Data) != len(expected) {
+			return false
+		}
+		for _, child := range p.Children.Data {
+			if _, ok := expected[child.ID]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// makeImageMatcher returns a matcher for a single-image post. For replies,
+// match strictly by parent post ID (which is unique within the recovery
+// window for posts from this user). For non-replies, match by exact text +
+// media type + non-reply state. The image URL stored on the post is Meta's
+// CDN URL, not ours, so we don't compare it.
+func makeImageMatcher(content *ImagePostContent) publishMatcher {
+	return func(p *Post) bool {
+		if p.MediaType != MediaTypeImage {
+			return false
+		}
+		if content.ReplyTo != "" {
+			return p.IsReply && repliedToID(p) == content.ReplyTo
+		}
+		return !p.IsReply && p.Text == content.Text
+	}
+}
+
+// makeVideoMatcher mirrors makeImageMatcher for video posts. After publish,
+// Meta may report video posts as media_type == "VIDEO" or "AUDIO" (for
+// audio-only uploads). Accept either.
+func makeVideoMatcher(content *VideoPostContent) publishMatcher {
+	return func(p *Post) bool {
+		if p.MediaType != MediaTypeVideo && p.MediaType != MediaTypeAudio {
+			return false
+		}
+		if content.ReplyTo != "" {
+			return p.IsReply && repliedToID(p) == content.ReplyTo
+		}
+		return !p.IsReply && p.Text == content.Text
+	}
+}
+
+// makeTextMatcher returns a matcher for a text-only post. Replies match by
+// parent ID + text. Non-replies match by text + topic tag (the topic tag
+// disambiguates same-text posts across different topics).
+func makeTextMatcher(content *TextPostContent) publishMatcher {
+	wantTextType := MediaTypeResponseText
+	return func(p *Post) bool {
+		// Some text post variants may come back as TEXT_POST or omit
+		// media_type entirely. Accept both shapes.
+		if p.MediaType != "" && p.MediaType != wantTextType && p.MediaType != MediaTypeText {
+			return false
+		}
+		if p.Text != content.Text {
+			return false
+		}
+		if content.ReplyTo != "" {
+			return p.IsReply && repliedToID(p) == content.ReplyTo
+		}
+		return !p.IsReply && p.TopicTag == content.TopicTag
+	}
+}
+
+// repliedToID returns the parent post ID for a reply, preferring the
+// dedicated reply_to string field and falling back to the embedded
+// replied_to object. Returns "" if neither is populated.
+func repliedToID(p *Post) string {
+	if p.ReplyTo != "" {
+		return p.ReplyTo
+	}
+	if p.RepliedTo != nil {
+		return p.RepliedTo.ID
+	}
+	return ""
+}

--- a/posts_publish_recovery_test.go
+++ b/posts_publish_recovery_test.go
@@ -346,9 +346,56 @@ func TestCreateImagePost_QuotePostNotMistakenForRegular(t *testing.T) {
 	}
 }
 
+// TestCreateImagePost_RecoversRootByTopicTag covers the non-reply image case
+// where two posts in the recovery window share the same text and differ only
+// by topic_tag. The matcher must use topic_tag as a disambiguator (parity
+// with makeTextMatcher), not fail closed.
+func TestCreateImagePost_RecoversRootByTopicTag(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// Two non-reply image posts with identical captions. The one
+			// with the matching topic_tag must be selected — without
+			// topic_tag in the matcher, both would match and recovery
+			// would fail closed.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"wrong_topic_post","media_type":"IMAGE","is_reply":false,"text":"sunset","topic_tag":"OtherTopic"},
+                {"id":"recovered_post","media_type":"IMAGE","is_reply":false,"text":"sunset","topic_tag":"GoldenHour"}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	post, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		Text:     "sunset",
+		ImageURL: "https://example.com/img.jpg",
+		TopicTag: "GoldenHour",
+	})
+	if err != nil {
+		t.Fatalf("expected recovery via text+topic_tag match, got: %v", err)
+	}
+	if post == nil || post.ID != "recovered_post" {
+		t.Fatalf("expected recovered_post, got %#v", post)
+	}
+}
+
 // TestCreateImagePost_RecoversRootByText covers the non-reply image case
 // where we match on exact text equality. A different post with different
-// text in the recovery window must NOT be picked.
+// text in the recovery window must NOT be picked. No topic_tag is set,
+// confirming that empty-tag matches empty-tag.
 func TestCreateImagePost_RecoversRootByText(t *testing.T) {
 	containerStatus, _ := containerStatusHandler("PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/posts_publish_recovery_test.go
+++ b/posts_publish_recovery_test.go
@@ -232,11 +232,15 @@ func TestCreateImagePost_RecoversReplyByParentIDAndText(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Two replies to the same parent, only one matches our text:
+			// Two replies to the same parent, only one matches our text.
+			// Note: PostExtendedFields requests `replied_to` (object), not
+			// `reply_to` (string), so the production API populates p.RepliedTo
+			// — mirror that shape here so the test exercises the same code
+			// path repliedToID() takes in production.
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
-                {"id":"earlier_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id","text":"earlier comment"},
-                {"id":"recovered_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id","text":"the comment we just sent"}
+                {"id":"earlier_reply","media_type":"IMAGE","is_reply":true,"replied_to":{"id":"parent_post_id"},"text":"earlier comment"},
+                {"id":"recovered_reply","media_type":"IMAGE","is_reply":true,"replied_to":{"id":"parent_post_id"},"text":"the comment we just sent"}
             ]}`))
 		default:
 			http.NotFound(w, r)
@@ -277,10 +281,12 @@ func TestCreateImagePost_BlankTextReplyFailsClosed(t *testing.T) {
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
 			// A prior reply to the same parent. Without a discriminator,
-			// matching by reply_to alone would WRONGLY return this post.
+			// matching by parent ID alone would WRONGLY return this post.
+			// Use `replied_to` (object) to match the production API shape
+			// returned for PostExtendedFields.
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
-                {"id":"prior_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id","text":""}
+                {"id":"prior_reply","media_type":"IMAGE","is_reply":true,"replied_to":{"id":"parent_post_id"},"text":""}
             ]}`))
 		default:
 			http.NotFound(w, r)
@@ -377,6 +383,50 @@ func TestCreateImagePost_RecoversRootByText(t *testing.T) {
 	}
 	if post == nil || post.ID != "matching_post" {
 		t.Fatalf("expected matching_post, got %#v", post)
+	}
+}
+
+// TestCreateTextPost_RecoversAfterCode10 covers the text-post recovery path
+// end-to-end. Specifically, it exercises makeTextMatcher's TopicTag arm: two
+// posts in the recovery window share the same text but only one has our
+// topic_tag, so the matcher must disambiguate on TopicTag rather than just
+// returning the first text-match it encounters.
+func TestCreateTextPost_RecoversAfterCode10(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// Two non-reply text posts with identical text — only the
+			// matching topic_tag should disambiguate them.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"wrong_topic_post","media_type":"TEXT_POST","is_reply":false,"text":"daily standup","topic_tag":"OtherTopic"},
+                {"id":"recovered_post","media_type":"TEXT_POST","is_reply":false,"text":"daily standup","topic_tag":"MorningStandup"}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	post, err := client.CreateTextPost(context.Background(), &TextPostContent{
+		Text:     "daily standup",
+		TopicTag: "MorningStandup",
+	})
+	if err != nil {
+		t.Fatalf("expected text-post recovery to succeed, got: %v", err)
+	}
+	if post == nil || post.ID != "recovered_post" {
+		t.Fatalf("expected recovered_post, got %#v", post)
 	}
 }
 

--- a/posts_publish_recovery_test.go
+++ b/posts_publish_recovery_test.go
@@ -1,0 +1,380 @@
+package threads
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// containerStatusHandler returns a GET handler for /{containerID} that
+// reports FINISHED for the first call (so waitForContainerReady can proceed)
+// and the supplied recovery status for every subsequent call. This mirrors
+// the real container lifecycle: a container is FINISHED before publish,
+// then PUBLISHED (or still FINISHED, on real failure) after.
+func containerStatusHandler(statusAfterPublish string) (http.HandlerFunc, *int32) {
+	var calls int32
+	h := func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if n == 1 {
+			_, _ = w.Write([]byte(`{"id":"the_container","status":"FINISHED"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"the_container","status":"` + statusAfterPublish + `"}`))
+	}
+	return h, &calls
+}
+
+// TestCreateCarouselPost_RecoversAfterCode10 verifies the documented Meta
+// quirk where /threads_publish returns HTTP 500 + code 10 even though the
+// carousel was actually published. After the failed publish, recovery should:
+//   - confirm container status is PUBLISHED,
+//   - locate the published post via /me/threads, matching by exact child
+//     container ID set,
+//   - return that post as if the publish had succeeded.
+func TestCreateCarouselPost_RecoversAfterCode10(t *testing.T) {
+	var publishAttempts int32
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			atomic.AddInt32(&publishAttempts, 1)
+			// Mimic Meta: HTTP 500 with code 10 even though the publish
+			// will actually have been persisted server-side.
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test-trace"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_1"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_1","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_2"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child_2","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// Recovery's /me/threads lookup. Include the matching post plus
+			// an unrelated one to verify the matcher disambiguates.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"other_post","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"unrelated_a"},{"id":"unrelated_b"}]}},
+                {"id":"recovered_post","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"child_1"},{"id":"child_2"}]}}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	post, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err != nil {
+		t.Fatalf("expected recovery to succeed, got error: %v", err)
+	}
+	if post == nil || post.ID != "recovered_post" {
+		t.Fatalf("expected recovered_post, got %#v", post)
+	}
+	if got := atomic.LoadInt32(&publishAttempts); got != 1 {
+		t.Errorf("expected exactly 1 publish attempt (code 10 non-retryable), got %d", got)
+	}
+}
+
+// TestCreateCarouselPost_NoRecoveryWhenContainerNotPublished verifies that
+// when the container is NOT in PUBLISHED state, we surface the original
+// publish error instead of fabricating a recovery. This protects against
+// returning the wrong post when Meta really did reject the publish.
+func TestCreateCarouselPost_NoRecoveryWhenContainerNotPublished(t *testing.T) {
+	// Container stays FINISHED for both the wait-for-ready poll and the
+	// recovery status check — the publish really did fail.
+	containerStatus, _ := containerStatusHandler("FINISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err == nil {
+		t.Fatal("expected the original publish error to surface when container is not PUBLISHED")
+	}
+	// BaseError.Error() formats as "threads api error 10 (api_error): ...";
+	// match that prefix rather than a more fragile substring.
+	if !strings.Contains(err.Error(), "threads api error 10") {
+		t.Errorf("expected wrapped code 10 error, got: %v", err)
+	}
+}
+
+// TestCreateCarouselPost_NoRecoveryWhenNoMatch verifies we don't blindly
+// pick "the newest post since T0". If no post in the recovery window has
+// our child container IDs, recovery fails closed.
+func TestCreateCarouselPost_NoRecoveryWhenNoMatch(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// Recent posts exist but none have our children — must NOT
+			// accidentally pick the newest unrelated one.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"unrelated_a","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"x"},{"id":"y"}]}},
+                {"id":"unrelated_b","media_type":"IMAGE"}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err == nil {
+		t.Fatal("expected error when no post matches our child container IDs")
+	}
+}
+
+// TestCreateCarouselPost_FailClosedOnMultipleMatches: the matcher is supposed
+// to be unique per request, so >1 match means we'd be guessing. Confirm we
+// fail closed in that case rather than returning the wrong post.
+func TestCreateCarouselPost_FailClosedOnMultipleMatches(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/child_"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"child","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// Two posts share the same child container IDs — should not
+			// happen in practice (Meta mints fresh IDs) but exercise the
+			// fail-closed branch defensively.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"match_a","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"child_1"},{"id":"child_2"}]}},
+                {"id":"match_b","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"child_1"},{"id":"child_2"}]}}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
+		Text:     "carousel",
+		Children: []string{"child_1", "child_2"},
+	})
+	if err == nil {
+		t.Fatal("expected error on ambiguous match (>1)")
+	}
+}
+
+// TestCreateImagePost_RecoversReplyByParentID covers the single-image reply
+// case. Replies are uniquely identified by parent post ID, so matching by
+// reply_to is safe even under concurrent publishes.
+func TestCreateImagePost_RecoversReplyByParentID(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"recovered_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id"},
+                {"id":"unrelated_root_post","media_type":"IMAGE","is_reply":false}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	post, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		ReplyTo:  "parent_post_id",
+	})
+	if err != nil {
+		t.Fatalf("expected recovery for image reply, got: %v", err)
+	}
+	if post == nil || post.ID != "recovered_reply" {
+		t.Fatalf("expected recovered_reply, got %#v", post)
+	}
+}
+
+// TestCreateImagePost_RecoversRootByText covers the non-reply image case
+// where we match on exact text equality. A different post with different
+// text in the recovery window must NOT be picked.
+func TestCreateImagePost_RecoversRootByText(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"different_text_post","media_type":"IMAGE","is_reply":false,"text":"different text"},
+                {"id":"matching_post","media_type":"IMAGE","is_reply":false,"text":"hello world"}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	post, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		Text:     "hello world",
+		ImageURL: "https://example.com/img.jpg",
+	})
+	if err != nil {
+		t.Fatalf("expected recovery via text match, got: %v", err)
+	}
+	if post == nil || post.ID != "matching_post" {
+		t.Fatalf("expected matching_post, got %#v", post)
+	}
+}
+
+// TestRecovery_NotTriggeredForNonCode10 verifies recovery is gated on the
+// code-10 pattern. For other publish failures (e.g. validation error code
+// 100), recovery must NOT issue the /me/threads lookup — that lookup is the
+// signal that recovery actually fired.
+func TestRecovery_NotTriggeredForNonCode10(t *testing.T) {
+	var threadsListCalls int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			// Validation error (code 100), not the ambiguous publish pattern.
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(`{"error":{"message":"Param creation_id must be a number","type":"THApiException","code":100,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"image_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/image_container"):
+			// Container is ready for publish (FINISHED is the expected
+			// state at this point in the flow).
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"image_container","status":"FINISHED"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// If this is hit, recovery erroneously fired for non-code-10.
+			atomic.AddInt32(&threadsListCalls, 1)
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		Text:     "hello",
+		ImageURL: "https://example.com/img.jpg",
+	})
+	if err == nil {
+		t.Fatal("expected error from code 100")
+	}
+	if got := atomic.LoadInt32(&threadsListCalls); got != 0 {
+		t.Errorf("recovery should not fire for code 100; /me/threads was queried %d times", got)
+	}
+}
+
+// TestRecovery_NotRecoveredErrorSurfacesOriginal verifies that when
+// recovery is attempted but fails to find a matching post, the caller-facing
+// path surfaces the original publish error — not errPublishNotRecovered.
+func TestRecovery_NotRecoveredErrorSurfacesOriginal(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[]}`)) // no matches
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		Text:     "hello",
+		ImageURL: "https://example.com/img.jpg",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, errPublishNotRecovered) {
+		t.Fatal("expected the original publish error to surface, not errPublishNotRecovered")
+	}
+	if !strings.Contains(err.Error(), "threads api error 10") {
+		t.Errorf("expected original publish error (code 10) in chain, got: %v", err)
+	}
+}

--- a/posts_publish_recovery_test.go
+++ b/posts_publish_recovery_test.go
@@ -215,10 +215,10 @@ func TestCreateCarouselPost_FailClosedOnMultipleMatches(t *testing.T) {
 	}
 }
 
-// TestCreateImagePost_RecoversReplyByParentID covers the single-image reply
-// case. Replies are uniquely identified by parent post ID, so matching by
-// reply_to is safe even under concurrent publishes.
-func TestCreateImagePost_RecoversReplyByParentID(t *testing.T) {
+// TestCreateImagePost_RecoversReplyByParentIDAndText covers the single-image
+// reply case where the caller supplies non-empty text. Parent ID alone is
+// not unique across replies, so the matcher also requires text equality.
+func TestCreateImagePost_RecoversReplyByParentIDAndText(t *testing.T) {
 	containerStatus, _ := containerStatusHandler("PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -232,10 +232,11 @@ func TestCreateImagePost_RecoversReplyByParentID(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// Two replies to the same parent, only one matches our text:
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
-                {"id":"recovered_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id"},
-                {"id":"unrelated_root_post","media_type":"IMAGE","is_reply":false}
+                {"id":"earlier_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id","text":"earlier comment"},
+                {"id":"recovered_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id","text":"the comment we just sent"}
             ]}`))
 		default:
 			http.NotFound(w, r)
@@ -246,12 +247,96 @@ func TestCreateImagePost_RecoversReplyByParentID(t *testing.T) {
 	post, err := client.CreateImagePost(context.Background(), &ImagePostContent{
 		ImageURL: "https://example.com/img.jpg",
 		ReplyTo:  "parent_post_id",
+		Text:     "the comment we just sent",
 	})
 	if err != nil {
 		t.Fatalf("expected recovery for image reply, got: %v", err)
 	}
 	if post == nil || post.ID != "recovered_reply" {
 		t.Fatalf("expected recovered_reply, got %#v", post)
+	}
+}
+
+// TestCreateImagePost_BlankTextReplyFailsClosed verifies that an image reply
+// with no text and no quoted post — which has no unique discriminator beyond
+// parent ID — does NOT recover, even if a prior reply to the same parent is
+// visible in the recovery window. This protects callers (e.g. chained reply
+// flows) from threading subsequent work off the wrong post ID.
+func TestCreateImagePost_BlankTextReplyFailsClosed(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// A prior reply to the same parent. Without a discriminator,
+			// matching by reply_to alone would WRONGLY return this post.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"prior_reply","media_type":"IMAGE","is_reply":true,"reply_to":"parent_post_id","text":""}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		ReplyTo:  "parent_post_id",
+		// Text and QuotedPostID both empty — no unique signal.
+	})
+	if err == nil {
+		t.Fatal("expected fail-closed for blank-text non-quote image reply (would otherwise return prior_reply)")
+	}
+	if !strings.Contains(err.Error(), "threads api error 10") {
+		t.Errorf("expected original code 10 error to surface, got: %v", err)
+	}
+}
+
+// TestCreateImagePost_QuotePostNotMistakenForRegular verifies the quote-state
+// gate: if the caller asked for a non-quote image but a same-text quote post
+// shows up in the recovery window, the matcher must NOT pick it.
+func TestCreateImagePost_QuotePostNotMistakenForRegular(t *testing.T) {
+	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			// Same text, but it's a quote post — we asked for a regular
+			// post, so it must NOT match.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"a_quote_post","media_type":"IMAGE","is_reply":false,"text":"hello","is_quote_post":true,"quoted_post":{"id":"some_other_post"}}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		Text:     "hello",
+		ImageURL: "https://example.com/img.jpg",
+		// No QuotedPostID → must only match non-quote posts.
+	})
+	if err == nil {
+		t.Fatal("expected fail-closed when only candidate is a quote post and caller asked for non-quote")
 	}
 }
 


### PR DESCRIPTION
## Summary

Meta's `/threads_publish` endpoint returns HTTP 5xx with error code 10 ("Application does not have permission for this action") for some app/permission configurations even when the publish actually succeeded server-side. That caused two production problems for callers (observed on the fia-f1-docs-bot deployment):

- **Wasted quota.** The 5xx triggered the standard retry path, burning the 250-post/24h publishing quota on attempts that could never succeed — the container was already in `PUBLISHED` state.
- **False-failure → duplicates.** `publishContainer` returned an error, so callers had no way to learn about the post that was actually created. They marked the work as failed and re-ran it on the next cycle, creating new media containers and trying to publish them — which Meta also accepts the first time and reports as a code-10 failure, ad infinitum.

This change implements Meta's documented recovery flow ([troubleshooting docs — "Publishing Does Not Return a Media ID"](https://developers.facebook.com/docs/threads/troubleshooting#publishing-does-not-return-a-media-id)): when the publish call errors, check the container's status — if `PUBLISHED`, the publish actually succeeded and the caller can be handed the real post.

### Changes

- `http_client.go` — new `isNonRetryablePermanentErrorCode(int) bool` helper. Code 10 is now treated as non-retryable so the publish is attempted **exactly once**.
- `posts_publish_recovery.go` (new) — `tryRecoverPublishedPost` gates on container `status == PUBLISHED`, then locates the published post via `GET /me/threads?since=publishStart` and a content-specific matcher.

  **Matcher contracts (designed to be unique per request, including under concurrent publishes from the same user):**
  - **carousel** — exact set equality of child container IDs. Collision-proof: Meta mints fresh IDs per `CreateMediaContainer`.
  - **image/video reply** — parent post ID **plus** a unique discriminator (exact text equality OR matching `quoted_post_id`). Blank-text non-quote replies cannot be safely disambiguated from prior replies to the same parent and **fail closed**, surfacing the original publish error.
  - **image/video root** — exact text + topic_tag + non-reply state (topic_tag matches `makeTextMatcher`'s tie-breaker for same-text posts across different topics).
  - **text reply** — exact text + parent ID (text posts always have non-empty text per upstream validation).
  - **text root** — exact text + topic_tag.
  - Every matcher also gates on quote state via `quoteMatches`, so a quote post cannot masquerade as a regular post (or vice-versa) during recovery.

  Multiple matches and zero matches both fail closed, surfacing the original publish error rather than guessing.
- `posts_create.go` — `CreateTextPost`, `CreateImagePost`, `CreateVideoPost`, `CreateCarouselPost` now invoke `recoverFromPublishError` after a failed `publishContainer`. Non-code-10 errors short-circuit recovery, so there's no extra Meta round-trip for genuine failures.

### Tests

- `TestIsRetryableError_Code10NotRetried` — code 10 + HTTP 5xx is non-retryable; other 5xx codes remain retryable.
- `TestCreateCarouselPost_RecoversAfterCode10` — happy path: publish "fails", container is `PUBLISHED`, post is recovered by child-ID match; asserts the publish was tried exactly once.
- `TestCreateCarouselPost_NoRecoveryWhenContainerNotPublished` — container stayed `FINISHED`: original error surfaces.
- `TestCreateCarouselPost_NoRecoveryWhenNoMatch` — `PUBLISHED` container but no matching post: fail closed.
- `TestCreateCarouselPost_FailClosedOnMultipleMatches` — defensive: ambiguous match → fail closed.
- `TestCreateImagePost_RecoversReplyByParentIDAndText` — reply recovery requires both parent ID and text equality; mock uses the production `replied_to` object shape.
- `TestCreateImagePost_BlankTextReplyFailsClosed` — image reply with no text and no quoted post fails closed, even when a prior reply to the same parent is in the recovery window (would otherwise return the wrong post).
- `TestCreateImagePost_QuotePostNotMistakenForRegular` — quote-state gate: a same-text quote post does not match a non-quote request.
- `TestCreateImagePost_RecoversRootByTopicTag` — two same-text non-reply image posts in the recovery window disambiguated only by `topic_tag`.
- `TestCreateImagePost_RecoversRootByText` — root image matched by exact text (no topic_tag set; confirms empty-tag matches empty-tag).
- `TestCreateTextPost_RecoversAfterCode10` — text-post recovery; two same-text posts in the window are disambiguated only by `topic_tag`, exercising `makeTextMatcher`'s `TopicTag` arm end-to-end.
- `TestRecovery_NotTriggeredForNonCode10` — code 100 does not trigger the `/me/threads` lookup.
- `TestRecovery_NotRecoveredErrorSurfacesOriginal` — sentinel never leaks past the Create*Post wrapper.

Full suite: `go test ./...` passes locally.