### PR TITLE
Recovery hardening: bounded polling, content-based carousel match, root discriminator

### DIFF
--- a/posts_create.go
+++ b/posts_create.go
@@ -46,10 +46,7 @@ func (c *Client) CreateTextPost(ctx context.Context, content *TextPostContent) (
 	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
-		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeTextMatcher(content)); recErr == nil {
-			return recovered, nil
-		}
-		return nil, fmt.Errorf("failed to publish text post: %w", err)
+		return c.recoverOrWrap(ctx, containerID, publishStart, err, makeTextMatcher(content), "failed to publish text post: %w")
 	}
 
 	return post, nil
@@ -86,10 +83,7 @@ func (c *Client) CreateImagePost(ctx context.Context, content *ImagePostContent)
 	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
-		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeImageMatcher(content)); recErr == nil {
-			return recovered, nil
-		}
-		return nil, fmt.Errorf("failed to publish image post: %w", err)
+		return c.recoverOrWrap(ctx, containerID, publishStart, err, makeImageMatcher(content), "failed to publish image post: %w")
 	}
 
 	return post, nil
@@ -126,10 +120,7 @@ func (c *Client) CreateVideoPost(ctx context.Context, content *VideoPostContent)
 	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
-		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeVideoMatcher(content)); recErr == nil {
-			return recovered, nil
-		}
-		return nil, fmt.Errorf("failed to publish video post: %w", err)
+		return c.recoverOrWrap(ctx, containerID, publishStart, err, makeVideoMatcher(content), "failed to publish video post: %w")
 	}
 
 	return post, nil
@@ -206,10 +197,7 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
-		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeCarouselMatcher(content)); recErr == nil {
-			return recovered, nil
-		}
-		return nil, fmt.Errorf("failed to publish carousel post: %w", err)
+		return c.recoverOrWrap(ctx, containerID, publishStart, err, makeCarouselMatcher(content), "failed to publish carousel post: %w")
 	}
 
 	return post, nil

--- a/posts_create.go
+++ b/posts_create.go
@@ -206,7 +206,7 @@ func (c *Client) CreateCarouselPost(ctx context.Context, content *CarouselPostCo
 	publishStart := time.Now()
 	post, err := c.publishContainer(ctx, containerID)
 	if err != nil {
-		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeCarouselMatcher(content.Children)); recErr == nil {
+		if recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, err, makeCarouselMatcher(content)); recErr == nil {
 			return recovered, nil
 		}
 		return nil, fmt.Errorf("failed to publish carousel post: %w", err)

--- a/posts_publish_recovery.go
+++ b/posts_publish_recovery.go
@@ -13,6 +13,21 @@ import (
 // enough to risk collisions with prior unrelated publishes.
 const publishRecoveryWindow = 5 * time.Second
 
+// Recovery polling bounds. Both gates (container status flip to PUBLISHED
+// and the /me/threads index seeing our new post) can race with Meta
+// returning the code-10 error response, so do a few brief polls before
+// concluding the publish really failed. Total worst-case latency is
+// (maxStatusPolls + maxListPolls - 2) * pollInterval, kept small enough
+// to not dominate caller-visible latency.
+//
+// Declared as vars (not consts) so tests in this package can shrink the
+// interval without paying the production wait time.
+var (
+	maxRecoveryStatusPolls = 5
+	maxRecoveryListPolls   = 3
+	recoveryPollInterval   = 1 * time.Second
+)
+
 // errPublishNotRecovered is the sentinel returned by tryRecoverPublishedPost
 // when no recovery is possible. Callers should surface the original publish
 // error in this case, not the recovery error.
@@ -20,8 +35,9 @@ var errPublishNotRecovered = errors.New("publish not recovered")
 
 // publishMatcher reports whether a post returned from /me/threads is the
 // post that the current publish attempt produced. Matchers are content-type
-// specific (carousel matches by child container IDs, image-reply matches by
-// reply_to, etc.); see makeXxxMatcher helpers below.
+// specific (carousel matches by text + topic_tag + children count + reply/
+// quote state; image-reply by parent ID + text, etc.); see makeXxxMatcher
+// helpers below.
 type publishMatcher func(*Post) bool
 
 // shouldAttemptPublishRecovery reports whether err matches the documented
@@ -60,107 +76,183 @@ func (c *Client) recoverFromPublishError(
 // tryRecoverPublishedPost implements the Meta-documented recovery flow for
 // /threads_publish calls that error out despite succeeding server-side:
 //
-//  1. Confirm the container's status is PUBLISHED (cheap, single GET). If it
-//     isn't, the publish really did fail and there's nothing to recover.
+//  1. Poll the container's status briefly until it flips to PUBLISHED.
+//     The publish response can arrive before the container's status row
+//     has been updated, so a single read can spuriously see FINISHED and
+//     mistake a successful publish for a real failure.
 //  2. List recent posts authored by this user since publishStart (minus a
-//     small skew buffer) and apply the caller-supplied matcher.
-//  3. Return the unique matching post, or errPublishNotRecovered if zero or
-//     more than one posts match.
+//     small skew buffer) and apply the caller-supplied matcher. The post
+//     can lag the container flip in the /me/threads index, so retry the
+//     list lookup briefly before giving up.
+//  3. Return the unique matching post, or errPublishNotRecovered if zero
+//     or more than one posts match across all attempts.
 //
 // The matcher MUST be content-specific enough to be unique per request even
-// under concurrent publishes from the same user. For carousels, that's the
-// set of child container IDs (Meta mints fresh IDs per CreateMediaContainer
-// call, so two concurrent carousels never share children). For other post
-// types, see the corresponding makeXxxMatcher helper.
+// under concurrent publishes from the same user. See each makeXxxMatcher
+// helper for the per-type guarantees.
 //
-// The function intentionally returns errPublishNotRecovered (not the original
-// publish error) when recovery isn't possible — the caller is expected to
-// propagate the original error in that case.
+// Returns errPublishNotRecovered (not the original publish error) when
+// recovery isn't possible — the caller is expected to propagate the
+// original error in that case.
 func (c *Client) tryRecoverPublishedPost(
 	ctx context.Context,
 	containerID string,
 	publishStart time.Time,
 	match publishMatcher,
 ) (*Post, error) {
-	// Gate 1: container must be in PUBLISHED state. This is the canonical
-	// signal from Meta that the publish actually succeeded.
-	status, err := c.GetContainerStatus(ctx, ContainerID(containerID))
-	if err != nil {
-		return nil, fmt.Errorf("recovery: failed to fetch container status: %w", err)
-	}
-	if status.Status != ContainerStatusPublished {
-		return nil, errPublishNotRecovered
+	// Gate 1: poll until the container reports PUBLISHED. Terminal failure
+	// states (ERROR, EXPIRED) short-circuit to "not recovered" — the
+	// publish really didn't succeed.
+	if err := c.waitForContainerPublished(ctx, ContainerID(containerID)); err != nil {
+		return nil, err
 	}
 
-	// Gate 2: a matching post must exist in the user's recent timeline,
-	// posted after we started the publish attempt.
+	// Gate 2: poll /me/threads for a matching post. The carousel just
+	// flipped to PUBLISHED but indexing may lag slightly; retry briefly.
 	userID := c.getUserID()
 	if userID == "" {
 		return nil, NewAuthenticationError(401, "User ID not available", "Cannot determine user ID from token")
 	}
 	sinceTS := publishStart.Add(-publishRecoveryWindow).Unix()
-	posts, err := c.GetUserPostsWithOptions(ctx, UserID(userID), &PostsOptions{
-		Limit: 25,
-		Since: sinceTS,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("recovery: failed to list recent posts: %w", err)
+
+	for attempt := 0; attempt < maxRecoveryListPolls; attempt++ {
+		if attempt > 0 {
+			if err := sleepCtx(ctx, recoveryPollInterval); err != nil {
+				return nil, err
+			}
+		}
+
+		posts, err := c.GetUserPostsWithOptions(ctx, UserID(userID), &PostsOptions{
+			Limit: 25,
+			Since: sinceTS,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("recovery: failed to list recent posts: %w", err)
+		}
+
+		// Find a unique match. Fail closed on multiple matches — matchers
+		// are designed to be unique per request, so >1 match means we'd
+		// be guessing; better to surface the original publish error.
+		var found *Post
+		ambiguous := false
+		for i := range posts.Data {
+			if match(&posts.Data[i]) {
+				if found != nil {
+					ambiguous = true
+					break
+				}
+				found = &posts.Data[i]
+			}
+		}
+		if ambiguous {
+			return nil, errPublishNotRecovered
+		}
+		if found != nil {
+			return found, nil
+		}
+		// Zero matches yet — fall through to next poll.
 	}
 
-	// Find a unique match. Fail closed on multiple matches — the matcher
-	// is supposed to be unique per request, so >1 match means something
-	// is off and we'd rather surface the original error than return the
-	// wrong post.
-	var found *Post
-	for i := range posts.Data {
-		if match(&posts.Data[i]) {
-			if found != nil {
-				return nil, errPublishNotRecovered
-			}
-			found = &posts.Data[i]
-		}
-	}
-	if found == nil {
-		return nil, errPublishNotRecovered
-	}
-	return found, nil
+	return nil, errPublishNotRecovered
 }
 
-// makeCarouselMatcher returns a matcher that identifies the published
-// carousel post by exact equality of its child container ID set. Carousel
-// child container IDs are minted per CreateMediaContainer call and are
-// globally unique, so this is collision-proof across concurrent publishes.
-func makeCarouselMatcher(childContainerIDs []string) publishMatcher {
-	expected := make(map[string]struct{}, len(childContainerIDs))
-	for _, id := range childContainerIDs {
-		expected[id] = struct{}{}
+// waitForContainerPublished polls the container's status endpoint until it
+// reports PUBLISHED, returns a terminal-failure sentinel, or the poll budget
+// is exhausted. Returns nil only when PUBLISHED is observed.
+func (c *Client) waitForContainerPublished(ctx context.Context, containerID ContainerID) error {
+	for attempt := 0; attempt < maxRecoveryStatusPolls; attempt++ {
+		if attempt > 0 {
+			if err := sleepCtx(ctx, recoveryPollInterval); err != nil {
+				return err
+			}
+		}
+
+		status, err := c.GetContainerStatus(ctx, containerID)
+		if err != nil {
+			return fmt.Errorf("recovery: failed to fetch container status: %w", err)
+		}
+		switch status.Status {
+		case ContainerStatusPublished:
+			return nil
+		case ContainerStatusError, ContainerStatusExpired:
+			// Terminal — the publish really did fail. No point polling.
+			return errPublishNotRecovered
+		}
+		// FINISHED or IN_PROGRESS — keep polling.
 	}
+	return errPublishNotRecovered
+}
+
+// sleepCtx waits for d or returns ctx's error if it's cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// makeCarouselMatcher returns a matcher for a published carousel post.
+//
+// Note on why we don't match by child IDs: Meta's create endpoint takes
+// MEDIA CONTAINER IDs in the `children` parameter, but the read endpoint
+// (/me/threads with `children` field) returns CHILD POST IDs of the
+// individual published children — these are different IDs. Verified in
+// production: a carousel published with container IDs [C1..Cn] reads
+// back with children [P1..Pn] where each Pi is its own /post/{shortcode}
+// permalink. So matching by ID-set never works after publish.
+//
+// Instead we match by content: text + topic_tag + reply/quote state +
+// children count. Same uniqueness rules as image-root: a unique
+// discriminator (non-empty text, topic_tag, or quoted_post_id) is
+// required for non-reply carousels, and text-or-quote is required for
+// reply carousels. Caller-side carousels with blank text and no quote
+// can't be safely recovered — but the bot-style "chunked reply chain"
+// flow that hits this case is already loss-tolerant by design.
+func makeCarouselMatcher(content *CarouselPostContent) publishMatcher {
+	want := len(content.Children)
 	return func(p *Post) bool {
 		if p.MediaType != MediaTypeResponseCarousel {
 			return false
 		}
-		if p.Children == nil || len(p.Children.Data) != len(expected) {
+		if p.Children == nil || len(p.Children.Data) != want {
 			return false
 		}
-		for _, child := range p.Children.Data {
-			if _, ok := expected[child.ID]; !ok {
+		if !quoteMatches(p, content.QuotedPostID) {
+			return false
+		}
+		if content.ReplyTo == "" {
+			if !rootHasUniqueDiscriminator(content.Text, content.TopicTag, content.QuotedPostID) {
 				return false
 			}
+			return !p.IsReply && p.Text == content.Text && p.TopicTag == content.TopicTag
 		}
-		return true
+		if !p.IsReply || repliedToID(p) != content.ReplyTo {
+			return false
+		}
+		if !replyHasUniqueDiscriminator(content.Text, content.QuotedPostID) {
+			return false
+		}
+		return p.Text == content.Text
 	}
 }
 
-// makeImageMatcher returns a matcher for a single-image post. For replies,
-// parent ID alone is not unique — a caller can legitimately publish multiple
-// replies to the same parent, and clock skew or propagation delay could put
-// a prior reply inside the recovery window. So for replies we additionally
-// require exact text equality or a matching quoted-post target; blank-text
-// non-quote replies fail closed because they have no unique signal. For
-// non-replies, exact text + topic_tag + non-reply state is the disambiguator
-// — topic_tag breaks ties between same-text posts across different topics,
-// matching makeTextMatcher's behavior. The image URL stored on the post is
-// Meta's CDN URL, not ours, so we don't compare it.
+// makeImageMatcher returns a matcher for a single-image post.
+//
+// For non-replies, exact text + topic_tag + non-reply state is the match
+// key; we additionally require at least one of (text, topic_tag,
+// quoted_post_id) to be non-empty, because an image-only root with no
+// text and no tag has no unique signal — matching by media_type +
+// !is_reply alone would let any prior unrelated image post in the window
+// pass.
+//
+// For replies, parent ID is necessary but not sufficient (multiple
+// replies to the same parent are valid). Require non-empty text or a
+// matching quoted-post target; blank-text non-quote replies fail closed.
+//
+// The image URL stored on the post is Meta's CDN URL, not ours, so we
+// don't compare it.
 func makeImageMatcher(content *ImagePostContent) publishMatcher {
 	return func(p *Post) bool {
 		if p.MediaType != MediaTypeImage {
@@ -170,6 +262,9 @@ func makeImageMatcher(content *ImagePostContent) publishMatcher {
 			return false
 		}
 		if content.ReplyTo == "" {
+			if !rootHasUniqueDiscriminator(content.Text, content.TopicTag, content.QuotedPostID) {
+				return false
+			}
 			return !p.IsReply && p.Text == content.Text && p.TopicTag == content.TopicTag
 		}
 		if !p.IsReply || repliedToID(p) != content.ReplyTo {
@@ -184,9 +279,9 @@ func makeImageMatcher(content *ImagePostContent) publishMatcher {
 
 // makeVideoMatcher mirrors makeImageMatcher for video posts. After publish,
 // Meta may report video posts as media_type == "VIDEO" or "AUDIO" (for
-// audio-only uploads). Accept either. The same reply-uniqueness rules apply:
-// blank-text non-quote replies fail closed. Non-replies disambiguate on
-// text + topic_tag.
+// audio-only uploads). Accept either. Same uniqueness rules: blank-text
+// non-quote replies fail closed; non-reply posts require a non-empty
+// discriminator (text, topic_tag, or quoted_post_id).
 func makeVideoMatcher(content *VideoPostContent) publishMatcher {
 	return func(p *Post) bool {
 		if p.MediaType != MediaTypeVideo && p.MediaType != MediaTypeAudio {
@@ -196,6 +291,9 @@ func makeVideoMatcher(content *VideoPostContent) publishMatcher {
 			return false
 		}
 		if content.ReplyTo == "" {
+			if !rootHasUniqueDiscriminator(content.Text, content.TopicTag, content.QuotedPostID) {
+				return false
+			}
 			return !p.IsReply && p.Text == content.Text && p.TopicTag == content.TopicTag
 		}
 		if !p.IsReply || repliedToID(p) != content.ReplyTo {
@@ -211,8 +309,8 @@ func makeVideoMatcher(content *VideoPostContent) publishMatcher {
 // makeTextMatcher returns a matcher for a text-only post. Text posts always
 // have non-empty text (validated upstream), so text equality is itself a
 // strong discriminator. Quote state must match in both directions, and
-// non-replies additionally compare topic_tag to disambiguate same-text posts
-// across different topics.
+// non-replies additionally compare topic_tag to disambiguate same-text
+// posts across different topics.
 func makeTextMatcher(content *TextPostContent) publishMatcher {
 	wantTextType := MediaTypeResponseText
 	return func(p *Post) bool {
@@ -237,8 +335,8 @@ func makeTextMatcher(content *TextPostContent) publishMatcher {
 // quoteMatches reports whether a retrieved post's quote state aligns with
 // what the caller asked for. wantQuotedID == "" means "must not be a quote
 // post"; non-empty means "must be a quote of that specific post". Matching
-// across the quote/non-quote boundary would let a regular post masquerade as
-// a quote post (or vice-versa) during recovery.
+// across the quote/non-quote boundary would let a regular post masquerade
+// as a quote post (or vice-versa) during recovery.
 func quoteMatches(p *Post, wantQuotedID string) bool {
 	if wantQuotedID == "" {
 		return !p.IsQuotePost
@@ -254,6 +352,16 @@ func quoteMatches(p *Post, wantQuotedID string) bool {
 // same parent. Without one of these signals we'd be guessing.
 func replyHasUniqueDiscriminator(text, quotedPostID string) bool {
 	return text != "" || quotedPostID != ""
+}
+
+// rootHasUniqueDiscriminator reports whether a non-reply post has any
+// content signal that distinguishes it from prior unrelated posts in the
+// recovery window. An image-only or video-only root with empty text and
+// empty topic_tag has no such signal — matching by media_type + !is_reply
+// alone would accept any prior post of the same type. Such recoveries
+// fail closed.
+func rootHasUniqueDiscriminator(text, topicTag, quotedPostID string) bool {
+	return text != "" || topicTag != "" || quotedPostID != ""
 }
 
 // repliedToID returns the parent post ID for a reply, preferring the

--- a/posts_publish_recovery.go
+++ b/posts_publish_recovery.go
@@ -73,6 +73,44 @@ func (c *Client) recoverFromPublishError(
 	return c.tryRecoverPublishedPost(ctx, containerID, publishStart, match)
 }
 
+// recoverOrWrap is the canonical post-publish-error glue for Create*Post:
+// it runs recovery, then turns the (recovered, recErr, publishErr) triple
+// into a single caller-facing return.
+//
+// Three outcomes:
+//
+//  1. Recovery succeeded → return the recovered post.
+//  2. Recovery was cut short by caller-context cancellation or deadline →
+//     propagate the ctx error verbatim. Callers (and any downstream
+//     classification, e.g. retry loops) rely on errors.Is(err, context.Xxx)
+//     to distinguish "the publish actually failed" from "we ran out of time
+//     during recovery"; swallowing the ctx error into the original publish
+//     error breaks that distinction.
+//  3. Recovery couldn't help (errPublishNotRecovered, a recovery-side HTTP
+//     error that isn't a context error, etc.) → surface the ORIGINAL
+//     publish error wrapped by wrapFmt. This is the case where the publish
+//     itself is what the caller needs to see.
+//
+// wrapFmt is a fmt.Errorf format string with a single %w verb, e.g.
+// "failed to publish carousel post: %w".
+func (c *Client) recoverOrWrap(
+	ctx context.Context,
+	containerID string,
+	publishStart time.Time,
+	publishErr error,
+	match publishMatcher,
+	wrapFmt string,
+) (*Post, error) {
+	recovered, recErr := c.recoverFromPublishError(ctx, containerID, publishStart, publishErr, match)
+	if recErr == nil {
+		return recovered, nil
+	}
+	if errors.Is(recErr, context.Canceled) || errors.Is(recErr, context.DeadlineExceeded) {
+		return nil, recErr
+	}
+	return nil, fmt.Errorf(wrapFmt, publishErr)
+}
+
 // tryRecoverPublishedPost implements the Meta-documented recovery flow for
 // /threads_publish calls that error out despite succeeding server-side:
 //

--- a/posts_publish_recovery_test.go
+++ b/posts_publish_recovery_test.go
@@ -4,27 +4,50 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
-// containerStatusHandler returns a GET handler for /{containerID} that
-// reports FINISHED for the first call (so waitForContainerReady can proceed)
-// and the supplied recovery status for every subsequent call. This mirrors
-// the real container lifecycle: a container is FINISHED before publish,
-// then PUBLISHED (or still FINISHED, on real failure) after.
-func containerStatusHandler(statusAfterPublish string) (http.HandlerFunc, *int32) {
+// TestMain shrinks recoveryPollInterval so polling-path tests don't pay
+// the production 1s-per-attempt wait. All recovery tests in this file
+// rely on this; running them with the default interval would add several
+// seconds of wall time per case.
+func TestMain(m *testing.M) {
+	original := recoveryPollInterval
+	recoveryPollInterval = 5 * time.Millisecond
+	code := m.Run()
+	recoveryPollInterval = original
+	os.Exit(code)
+}
+
+// containerStatusHandler returns a GET handler for /{containerID} that:
+//   - emits FINISHED for the first call (waitForContainerReady, pre-publish),
+//   - then emits FINISHED for `finishedRepeats` more calls (recovery polling
+//     observing FINISHED before the status row flips),
+//   - then emits `terminalStatus` for every subsequent call.
+//
+// Pass finishedRepeats=0 to flip to the terminal status immediately on the
+// first recovery-side read (the common "post got created promptly" case).
+// Pass finishedRepeats > maxRecoveryStatusPolls to exhaust the recovery
+// poll budget while staying FINISHED.
+func containerStatusHandler(finishedRepeats int, terminalStatus string) (http.HandlerFunc, *int32) {
 	var calls int32
 	h := func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&calls, 1)
+		n := int(atomic.AddInt32(&calls, 1))
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		if n == 1 {
+		// Call 1 = waitForContainerReady (must see FINISHED to proceed).
+		// Calls 2..(1+finishedRepeats) = additional recovery polls that
+		// still see FINISHED.
+		// Calls after that = terminalStatus.
+		if n <= 1+finishedRepeats {
 			_, _ = w.Write([]byte(`{"id":"the_container","status":"FINISHED"}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"id":"the_container","status":"` + statusAfterPublish + `"}`))
+		_, _ = w.Write([]byte(`{"id":"the_container","status":"` + terminalStatus + `"}`))
 	}
 	return h, &calls
 }
@@ -32,20 +55,23 @@ func containerStatusHandler(statusAfterPublish string) (http.HandlerFunc, *int32
 // TestCreateCarouselPost_RecoversAfterCode10 verifies the documented Meta
 // quirk where /threads_publish returns HTTP 500 + code 10 even though the
 // carousel was actually published. After the failed publish, recovery should:
-//   - confirm container status is PUBLISHED,
-//   - locate the published post via /me/threads, matching by exact child
-//     container ID set,
+//   - confirm container status is PUBLISHED (polling-tolerant),
+//   - locate the published post via /me/threads using a content-based
+//     matcher (NOT the child container IDs we passed, which won't appear in
+//     the read-side `children` field — see makeCarouselMatcher's doc),
 //   - return that post as if the publish had succeeded.
+//
+// The mock returns child IDs of the form "published_child_*" to make the
+// container-vs-post-ID distinction explicit; a regression that re-introduces
+// children-ID set matching would fail to recover here.
 func TestCreateCarouselPost_RecoversAfterCode10(t *testing.T) {
 	var publishAttempts int32
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
 			atomic.AddInt32(&publishAttempts, 1)
-			// Mimic Meta: HTTP 500 with code 10 even though the publish
-			// will actually have been persisted server-side.
 			w.WriteHeader(500)
 			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test-trace"}}`))
 		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
@@ -60,12 +86,13 @@ func TestCreateCarouselPost_RecoversAfterCode10(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Recovery's /me/threads lookup. Include the matching post plus
-			// an unrelated one to verify the matcher disambiguates.
+			// Production-shape mock: children carry POST IDs of the
+			// individual published children, not the container IDs we
+			// passed in CreateCarouselPost.Children. We must match by
+			// content + count, not by ID set equality.
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
-                {"id":"other_post","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"unrelated_a"},{"id":"unrelated_b"}]}},
-                {"id":"recovered_post","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"child_1"},{"id":"child_2"}]}}
+                {"id":"recovered_post","media_type":"CAROUSEL_ALBUM","text":"my carousel","topic_tag":"F1Threads","is_reply":false,"children":{"data":[{"id":"published_child_a"},{"id":"published_child_b"}]}}
             ]}`))
 		default:
 			http.NotFound(w, r)
@@ -74,8 +101,9 @@ func TestCreateCarouselPost_RecoversAfterCode10(t *testing.T) {
 
 	client := testClient(t, http.HandlerFunc(handler))
 	post, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
-		Text:     "carousel",
+		Text:     "my carousel",
 		Children: []string{"child_1", "child_2"},
+		TopicTag: "F1Threads",
 	})
 	if err != nil {
 		t.Fatalf("expected recovery to succeed, got error: %v", err)
@@ -88,14 +116,13 @@ func TestCreateCarouselPost_RecoversAfterCode10(t *testing.T) {
 	}
 }
 
-// TestCreateCarouselPost_NoRecoveryWhenContainerNotPublished verifies that
-// when the container is NOT in PUBLISHED state, we surface the original
-// publish error instead of fabricating a recovery. This protects against
-// returning the wrong post when Meta really did reject the publish.
-func TestCreateCarouselPost_NoRecoveryWhenContainerNotPublished(t *testing.T) {
-	// Container stays FINISHED for both the wait-for-ready poll and the
-	// recovery status check — the publish really did fail.
-	containerStatus, _ := containerStatusHandler("FINISHED")
+// TestCreateCarouselPost_NoRecoveryWhenContainerNeverPublishes verifies that
+// when the container is NEVER seen in PUBLISHED state (stays FINISHED past
+// the poll budget), recovery exhausts polls and surfaces the original
+// publish error.
+func TestCreateCarouselPost_NoRecoveryWhenContainerNeverPublishes(t *testing.T) {
+	// Stay FINISHED for far more attempts than the poll budget.
+	containerStatus, _ := containerStatusHandler(maxRecoveryStatusPolls+2, "FINISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -121,20 +148,18 @@ func TestCreateCarouselPost_NoRecoveryWhenContainerNotPublished(t *testing.T) {
 		Children: []string{"child_1", "child_2"},
 	})
 	if err == nil {
-		t.Fatal("expected the original publish error to surface when container is not PUBLISHED")
+		t.Fatal("expected the original publish error to surface when container never reaches PUBLISHED")
 	}
-	// BaseError.Error() formats as "threads api error 10 (api_error): ...";
-	// match that prefix rather than a more fragile substring.
 	if !strings.Contains(err.Error(), "threads api error 10") {
 		t.Errorf("expected wrapped code 10 error, got: %v", err)
 	}
 }
 
-// TestCreateCarouselPost_NoRecoveryWhenNoMatch verifies we don't blindly
-// pick "the newest post since T0". If no post in the recovery window has
-// our child container IDs, recovery fails closed.
-func TestCreateCarouselPost_NoRecoveryWhenNoMatch(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+// TestCreateCarouselPost_NoRecoveryWhenContainerErrored confirms that a
+// terminal failure status (ERROR) short-circuits the status-polling loop
+// rather than burning the full poll budget.
+func TestCreateCarouselPost_NoRecoveryWhenContainerErrored(t *testing.T) {
+	containerStatus, statusCalls := containerStatusHandler(0, "ERROR")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -149,14 +174,6 @@ func TestCreateCarouselPost_NoRecoveryWhenNoMatch(t *testing.T) {
 			_, _ = w.Write([]byte(`{"id":"child","status":"FINISHED"}`))
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
-		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Recent posts exist but none have our children — must NOT
-			// accidentally pick the newest unrelated one.
-			w.WriteHeader(200)
-			_, _ = w.Write([]byte(`{"data":[
-                {"id":"unrelated_a","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"x"},{"id":"y"}]}},
-                {"id":"unrelated_b","media_type":"IMAGE"}
-            ]}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -168,15 +185,114 @@ func TestCreateCarouselPost_NoRecoveryWhenNoMatch(t *testing.T) {
 		Children: []string{"child_1", "child_2"},
 	})
 	if err == nil {
-		t.Fatal("expected error when no post matches our child container IDs")
+		t.Fatal("expected the original publish error to surface for ERROR container status")
+	}
+	// 1 call from waitForContainerReady + 1 call from recovery (saw ERROR,
+	// short-circuited). No additional polls.
+	if got := atomic.LoadInt32(statusCalls); got > 2 {
+		t.Errorf("recovery should short-circuit on terminal ERROR; status was queried %d times", got)
 	}
 }
 
-// TestCreateCarouselPost_FailClosedOnMultipleMatches: the matcher is supposed
-// to be unique per request, so >1 match means we'd be guessing. Confirm we
-// fail closed in that case rather than returning the wrong post.
+// TestRecovery_PollsContainerStatus exercises the bounded-polling path:
+// status reads return FINISHED a few times before flipping to PUBLISHED.
+// Without this loop, a race between Meta returning code 10 and the
+// container status row flipping would mis-classify a successful publish.
+func TestRecovery_PollsContainerStatus(t *testing.T) {
+	// 2 recovery-side FINISHED reads, then PUBLISHED.
+	containerStatus, _ := containerStatusHandler(2, "PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"recovered_post","media_type":"IMAGE","is_reply":false,"text":"the caption","topic_tag":"Hello"}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	post, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		Text:     "the caption",
+		ImageURL: "https://example.com/img.jpg",
+		TopicTag: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("expected recovery to succeed after status polling, got: %v", err)
+	}
+	if post.ID != "recovered_post" {
+		t.Fatalf("expected recovered_post, got %s", post.ID)
+	}
+}
+
+// TestRecovery_PollsUserPostsList exercises the list-polling path: the
+// first /me/threads call returns no match (index lag), a subsequent call
+// returns the published post. This is the failure mode observed in
+// production with v1.9.3 — recovery was correct, but a single immediate
+// list read missed the post.
+func TestRecovery_PollsUserPostsList(t *testing.T) {
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
+	var listCalls int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			n := atomic.AddInt32(&listCalls, 1)
+			if n == 1 {
+				// First read: index hasn't seen the post yet.
+				_, _ = w.Write([]byte(`{"data":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"recovered_post","media_type":"IMAGE","is_reply":false,"text":"the caption","topic_tag":"Hello"}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	post, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		Text:     "the caption",
+		ImageURL: "https://example.com/img.jpg",
+		TopicTag: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("expected recovery after list-polling to succeed, got: %v", err)
+	}
+	if post.ID != "recovered_post" {
+		t.Fatalf("expected recovered_post, got %s", post.ID)
+	}
+	if got := atomic.LoadInt32(&listCalls); got < 2 {
+		t.Errorf("expected at least 2 list calls (first empty, second matched), got %d", got)
+	}
+}
+
+// TestCreateCarouselPost_FailClosedOnMultipleMatches: matchers must be
+// unique per request, so >1 match means we'd be guessing. Confirm we fail
+// closed rather than returning the wrong post.
 func TestCreateCarouselPost_FailClosedOnMultipleMatches(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -192,13 +308,13 @@ func TestCreateCarouselPost_FailClosedOnMultipleMatches(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Two posts share the same child container IDs — should not
-			// happen in practice (Meta mints fresh IDs) but exercise the
-			// fail-closed branch defensively.
+			// Two same-text, same-count, same-tag carousel posts.
+			// Shouldn't happen in practice — exercise the fail-closed
+			// branch defensively.
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
-                {"id":"match_a","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"child_1"},{"id":"child_2"}]}},
-                {"id":"match_b","media_type":"CAROUSEL_ALBUM","children":{"data":[{"id":"child_1"},{"id":"child_2"}]}}
+                {"id":"match_a","media_type":"CAROUSEL_ALBUM","text":"carousel","topic_tag":"T","is_reply":false,"children":{"data":[{"id":"a"},{"id":"b"}]}},
+                {"id":"match_b","media_type":"CAROUSEL_ALBUM","text":"carousel","topic_tag":"T","is_reply":false,"children":{"data":[{"id":"c"},{"id":"d"}]}}
             ]}`))
 		default:
 			http.NotFound(w, r)
@@ -209,6 +325,7 @@ func TestCreateCarouselPost_FailClosedOnMultipleMatches(t *testing.T) {
 	_, err := client.CreateCarouselPost(context.Background(), &CarouselPostContent{
 		Text:     "carousel",
 		Children: []string{"child_1", "child_2"},
+		TopicTag: "T",
 	})
 	if err == nil {
 		t.Fatal("expected error on ambiguous match (>1)")
@@ -219,7 +336,7 @@ func TestCreateCarouselPost_FailClosedOnMultipleMatches(t *testing.T) {
 // reply case where the caller supplies non-empty text. Parent ID alone is
 // not unique across replies, so the matcher also requires text equality.
 func TestCreateImagePost_RecoversReplyByParentIDAndText(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -232,11 +349,8 @@ func TestCreateImagePost_RecoversReplyByParentIDAndText(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Two replies to the same parent, only one matches our text.
-			// Note: PostExtendedFields requests `replied_to` (object), not
-			// `reply_to` (string), so the production API populates p.RepliedTo
-			// — mirror that shape here so the test exercises the same code
-			// path repliedToID() takes in production.
+			// Production-shape mock: PostExtendedFields returns `replied_to`
+			// (object), not `reply_to` (string).
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
                 {"id":"earlier_reply","media_type":"IMAGE","is_reply":true,"replied_to":{"id":"parent_post_id"},"text":"earlier comment"},
@@ -261,13 +375,11 @@ func TestCreateImagePost_RecoversReplyByParentIDAndText(t *testing.T) {
 	}
 }
 
-// TestCreateImagePost_BlankTextReplyFailsClosed verifies that an image reply
-// with no text and no quoted post — which has no unique discriminator beyond
-// parent ID — does NOT recover, even if a prior reply to the same parent is
-// visible in the recovery window. This protects callers (e.g. chained reply
-// flows) from threading subsequent work off the wrong post ID.
+// TestCreateImagePost_BlankTextReplyFailsClosed: blank-text non-quote
+// replies have no unique discriminator beyond parent ID; recovery must
+// not guess.
 func TestCreateImagePost_BlankTextReplyFailsClosed(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -280,10 +392,6 @@ func TestCreateImagePost_BlankTextReplyFailsClosed(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// A prior reply to the same parent. Without a discriminator,
-			// matching by parent ID alone would WRONGLY return this post.
-			// Use `replied_to` (object) to match the production API shape
-			// returned for PostExtendedFields.
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
                 {"id":"prior_reply","media_type":"IMAGE","is_reply":true,"replied_to":{"id":"parent_post_id"},"text":""}
@@ -297,21 +405,18 @@ func TestCreateImagePost_BlankTextReplyFailsClosed(t *testing.T) {
 	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
 		ImageURL: "https://example.com/img.jpg",
 		ReplyTo:  "parent_post_id",
-		// Text and QuotedPostID both empty — no unique signal.
 	})
 	if err == nil {
-		t.Fatal("expected fail-closed for blank-text non-quote image reply (would otherwise return prior_reply)")
-	}
-	if !strings.Contains(err.Error(), "threads api error 10") {
-		t.Errorf("expected original code 10 error to surface, got: %v", err)
+		t.Fatal("expected fail-closed for blank-text non-quote image reply")
 	}
 }
 
-// TestCreateImagePost_QuotePostNotMistakenForRegular verifies the quote-state
-// gate: if the caller asked for a non-quote image but a same-text quote post
-// shows up in the recovery window, the matcher must NOT pick it.
-func TestCreateImagePost_QuotePostNotMistakenForRegular(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+// TestCreateImagePost_BlankTextBlankTagRootFailsClosed: a non-reply
+// image-only post with empty text AND empty topic_tag has no discriminator
+// — matching by media_type + !is_reply alone would accept any prior
+// unrelated image. Recovery must fail closed.
+func TestCreateImagePost_BlankTextBlankTagRootFailsClosed(t *testing.T) {
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -324,8 +429,46 @@ func TestCreateImagePost_QuotePostNotMistakenForRegular(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Same text, but it's a quote post — we asked for a regular
-			// post, so it must NOT match.
+			// A prior unrelated image post in the recovery window. Without
+			// the discriminator rule, matching by media_type+!is_reply
+			// alone would return this and the bot could chain off the
+			// wrong post ID.
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[
+                {"id":"prior_image","media_type":"IMAGE","is_reply":false,"text":"","topic_tag":""}
+            ]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
+		ImageURL: "https://example.com/img.jpg",
+		// Text, TopicTag, QuotedPostID all empty — no discriminator.
+	})
+	if err == nil {
+		t.Fatal("expected fail-closed for blank-text + blank-tag image root (no unique signal)")
+	}
+}
+
+// TestCreateImagePost_QuotePostNotMistakenForRegular verifies the quote-state
+// gate: if the caller asked for a non-quote image but a same-text quote post
+// shows up in the recovery window, the matcher must NOT pick it.
+func TestCreateImagePost_QuotePostNotMistakenForRegular(t *testing.T) {
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
                 {"id":"a_quote_post","media_type":"IMAGE","is_reply":false,"text":"hello","is_quote_post":true,"quoted_post":{"id":"some_other_post"}}
@@ -339,7 +482,6 @@ func TestCreateImagePost_QuotePostNotMistakenForRegular(t *testing.T) {
 	_, err := client.CreateImagePost(context.Background(), &ImagePostContent{
 		Text:     "hello",
 		ImageURL: "https://example.com/img.jpg",
-		// No QuotedPostID → must only match non-quote posts.
 	})
 	if err == nil {
 		t.Fatal("expected fail-closed when only candidate is a quote post and caller asked for non-quote")
@@ -348,10 +490,9 @@ func TestCreateImagePost_QuotePostNotMistakenForRegular(t *testing.T) {
 
 // TestCreateImagePost_RecoversRootByTopicTag covers the non-reply image case
 // where two posts in the recovery window share the same text and differ only
-// by topic_tag. The matcher must use topic_tag as a disambiguator (parity
-// with makeTextMatcher), not fail closed.
+// by topic_tag.
 func TestCreateImagePost_RecoversRootByTopicTag(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -364,10 +505,6 @@ func TestCreateImagePost_RecoversRootByTopicTag(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Two non-reply image posts with identical captions. The one
-			// with the matching topic_tag must be selected — without
-			// topic_tag in the matcher, both would match and recovery
-			// would fail closed.
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
                 {"id":"wrong_topic_post","media_type":"IMAGE","is_reply":false,"text":"sunset","topic_tag":"OtherTopic"},
@@ -393,11 +530,9 @@ func TestCreateImagePost_RecoversRootByTopicTag(t *testing.T) {
 }
 
 // TestCreateImagePost_RecoversRootByText covers the non-reply image case
-// where we match on exact text equality. A different post with different
-// text in the recovery window must NOT be picked. No topic_tag is set,
-// confirming that empty-tag matches empty-tag.
+// where text is set but topic_tag is empty. Empty-tag matches empty-tag.
 func TestCreateImagePost_RecoversRootByText(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -434,12 +569,10 @@ func TestCreateImagePost_RecoversRootByText(t *testing.T) {
 }
 
 // TestCreateTextPost_RecoversAfterCode10 covers the text-post recovery path
-// end-to-end. Specifically, it exercises makeTextMatcher's TopicTag arm: two
-// posts in the recovery window share the same text but only one has our
-// topic_tag, so the matcher must disambiguate on TopicTag rather than just
-// returning the first text-match it encounters.
+// end-to-end. Two same-text posts share the recovery window and only differ
+// by topic_tag.
 func TestCreateTextPost_RecoversAfterCode10(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -452,8 +585,6 @@ func TestCreateTextPost_RecoversAfterCode10(t *testing.T) {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// Two non-reply text posts with identical text — only the
-			// matching topic_tag should disambiguate them.
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[
                 {"id":"wrong_topic_post","media_type":"TEXT_POST","is_reply":false,"text":"daily standup","topic_tag":"OtherTopic"},
@@ -478,8 +609,8 @@ func TestCreateTextPost_RecoversAfterCode10(t *testing.T) {
 }
 
 // TestRecovery_NotTriggeredForNonCode10 verifies recovery is gated on the
-// code-10 pattern. For other publish failures (e.g. validation error code
-// 100), recovery must NOT issue the /me/threads lookup — that lookup is the
+// code-10 pattern. For other publish failures (e.g. validation code 100),
+// recovery must NOT issue extra Meta calls — the /me/threads lookup is the
 // signal that recovery actually fired.
 func TestRecovery_NotTriggeredForNonCode10(t *testing.T) {
 	var threadsListCalls int32
@@ -487,19 +618,15 @@ func TestRecovery_NotTriggeredForNonCode10(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
-			// Validation error (code 100), not the ambiguous publish pattern.
 			w.WriteHeader(400)
 			_, _ = w.Write([]byte(`{"error":{"message":"Param creation_id must be a number","type":"THApiException","code":100,"fbtrace_id":"test"}}`))
 		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"id":"image_container"}`))
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/image_container"):
-			// Container is ready for publish (FINISHED is the expected
-			// state at this point in the flow).
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"id":"image_container","status":"FINISHED"}`))
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
-			// If this is hit, recovery erroneously fired for non-code-10.
 			atomic.AddInt32(&threadsListCalls, 1)
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(`{"data":[]}`))
@@ -521,11 +648,12 @@ func TestRecovery_NotTriggeredForNonCode10(t *testing.T) {
 	}
 }
 
-// TestRecovery_NotRecoveredErrorSurfacesOriginal verifies that when
-// recovery is attempted but fails to find a matching post, the caller-facing
-// path surfaces the original publish error — not errPublishNotRecovered.
+// TestRecovery_NotRecoveredErrorSurfacesOriginal verifies that when recovery
+// is attempted but fails to find a matching post (after exhausting list
+// polls), the caller-facing path surfaces the original publish error —
+// not errPublishNotRecovered.
 func TestRecovery_NotRecoveredErrorSurfacesOriginal(t *testing.T) {
-	containerStatus, _ := containerStatusHandler("PUBLISHED")
+	containerStatus, _ := containerStatusHandler(0, "PUBLISHED")
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -539,7 +667,7 @@ func TestRecovery_NotRecoveredErrorSurfacesOriginal(t *testing.T) {
 			containerStatus(w, r)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
 			w.WriteHeader(200)
-			_, _ = w.Write([]byte(`{"data":[]}`)) // no matches
+			_, _ = w.Write([]byte(`{"data":[]}`)) // never indexed
 		default:
 			http.NotFound(w, r)
 		}

--- a/posts_publish_recovery_test.go
+++ b/posts_publish_recovery_test.go
@@ -15,12 +15,12 @@ import (
 // the production 1s-per-attempt wait. All recovery tests in this file
 // rely on this; running them with the default interval would add several
 // seconds of wall time per case.
+//
+// No restore needed: os.Exit terminates the process so any subsequent
+// statements would be dead code.
 func TestMain(m *testing.M) {
-	original := recoveryPollInterval
 	recoveryPollInterval = 5 * time.Millisecond
-	code := m.Run()
-	recoveryPollInterval = original
-	os.Exit(code)
+	os.Exit(m.Run())
 }
 
 // containerStatusHandler returns a GET handler for /{containerID} that:
@@ -645,6 +645,64 @@ func TestRecovery_NotTriggeredForNonCode10(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&threadsListCalls); got != 0 {
 		t.Errorf("recovery should not fire for code 100; /me/threads was queried %d times", got)
+	}
+}
+
+// TestRecovery_ContextCancellationPropagates verifies that if the caller's
+// context is cancelled (or deadline-exceeds) DURING recovery polling, the
+// caller-facing error is the context error — not the wrapped original
+// publish error. Downstream retry/classification code relies on
+// errors.Is(err, context.Canceled / DeadlineExceeded) to distinguish a
+// real publish failure from "we ran out of time during recovery."
+func TestRecovery_ContextCancellationPropagates(t *testing.T) {
+	// Hold poll interval long enough that the caller's short deadline
+	// fires while we're sleeping between polls. The default 5ms set in
+	// TestMain would race the deadline; override for this test only.
+	orig := recoveryPollInterval
+	recoveryPollInterval = 50 * time.Millisecond
+	t.Cleanup(func() { recoveryPollInterval = orig })
+
+	// Container stays FINISHED forever — polling never reaches PUBLISHED
+	// nor a terminal failure, so it WILL exhaust the budget. Caller's
+	// short deadline should fire well before we hit the budget.
+	containerStatus, _ := containerStatusHandler(maxRecoveryStatusPolls+5, "FINISHED")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads_publish"):
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"message":"Application does not have permission for this action","type":"THApiException","code":10,"fbtrace_id":"test"}}`))
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/12345/threads"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"the_container"}`))
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/the_container"):
+			containerStatus(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	client := testClient(t, http.HandlerFunc(handler))
+
+	// 30ms deadline << poll interval. Recovery should sleep, see ctx
+	// done, and bail with ctx.Err().
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := client.CreateImagePost(ctx, &ImagePostContent{
+		Text:     "hello",
+		ImageURL: "https://example.com/img.jpg",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded to propagate; got %v (Is(DeadlineExceeded)=%v)",
+			err, errors.Is(err, context.DeadlineExceeded))
+	}
+	// And specifically NOT the wrapped publish error.
+	if strings.Contains(err.Error(), "failed to publish image post") {
+		t.Errorf("expected raw ctx error, got wrapped publish error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three gaps in v1.9.3's recovery path that surfaced after deploying it to a real production caller (fia-f1-docs-bot). v1.9.3 made publish reliable in the *happy* recovery case; this PR makes it reliable in the *racy* and *carousel* cases too.

### 1. Single-shot polling raced against eventual consistency (P1)

`tryRecoverPublishedPost` did exactly one container-status read and one `/me/threads` list. In production traces from fiadocs:

| Doc | Post created (Meta-side) | Bot logged failure | Gap |
|---|---|---|---|
| Doc 2 (1 image) | 20:35:31 | 20:35:35 | **4 s** |
| Doc 3 (2-image carousel) | 20:35:43 | 20:35:48 | **5 s** |
| Doc 1 Visa (10-image carousel) | 20:36:31 | 20:36:35 | **4 s** |

`/me/threads` indexing trailed the publish by several seconds, so the single-shot lookup saw an empty data array and the matcher failed closed → original publish error surfaced → bot re-published next cycle.

Fix: bounded polling on both gates — 5× container-status (until `PUBLISHED`, `ERROR`, or `EXPIRED`), 3× `/me/threads` list (until a unique content match) — with a 1s interval. `TestMain` shrinks the interval to 5ms so the test suite stays sub-second. Terminal failure states (`ERROR`/`EXPIRED`) short-circuit the status loop instead of burning all 5 attempts.

### 2. Carousel matcher compared the wrong IDs (P2)

`makeCarouselMatcher` compared the retrieved post's `children.data[].id` to the container IDs the caller passed in `CreateCarouselPost.Children`. **Verified against a real published carousel**: Meta returns POST IDs (individual published children, each with its own `/post/{shortcode}` permalink) in that field after publish — NOT the original media-container IDs. So the match would *never* succeed in production.

Example: a fiadocs carousel published with container IDs `[C1…Cn]` reads back with `children.data[].id == [P1…Pn]` where `P1 = 18207875467337414` resolves to its own individual image post. `GET /18207875467337414` returns `{"id":"18207875467337414","media_type":"IMAGE","permalink":"https://www.threads.com/@fiadocs/post/DYkiJpWGP_K","owner":{"id":"27258452443753298"}}` — clearly a different ID space from container IDs.

Fix: rewritten as a content-based matcher with the same uniqueness rules as image-root — `text + topic_tag + reply/quote state + children count + non-empty discriminator`. Carousel test mocks now use production-shape children (post IDs distinct from container IDs) as a regression guard.

### 3. Image/video ROOT had no required discriminator (P2)

A non-reply image-only or video-only post with empty text AND empty topic_tag had no unique signal — matching by `media_type + !is_reply` alone would accept any prior unrelated post in the window. Reviewer-flagged.

Fix: non-reply matchers require at least one of (`text`, `topic_tag`, `quoted_post_id`) to be non-empty; otherwise fail closed. Mirrors the reply-discriminator rule already in place.

## Production validation

The original v1.9.3 recovery code did **not** actually recover any of the three fiadocs publishes that hit code-10 in production (the gap-table above). The actual fiadocs fix was scope-state related — but had we shipped these hardenings together, recovery WOULD have caught the single-image case (gap 1) and the carousels (gaps 1+2). The hardenings are now defensive insurance for any caller that hits a similar Meta backend quirk in the future.

## Tests

All recovery-related tests pass (`go test ./...`, full suite green):

- `TestRecovery_PollsContainerStatus` — status FINISHED → FINISHED → PUBLISHED still recovers
- `TestRecovery_PollsUserPostsList` — list empty → matched still recovers
- `TestCreateCarouselPost_RecoversAfterCode10` — mock now returns production-shape children (post IDs ≠ container IDs)
- `TestCreateCarouselPost_NoRecoveryWhenContainerNeverPublishes` — stays FINISHED past poll budget → original error
- `TestCreateCarouselPost_NoRecoveryWhenContainerErrored` — short-circuits on terminal ERROR; ≤ 2 status calls
- `TestCreateImagePost_BlankTextBlankTagRootFailsClosed` — no unique signal → fail closed
- existing reply-matcher, quote-gate, and topic-tag-disambiguation tests retained