### PR TITLE
fix: pin Go toolchain to 1.25.11 to resolve stdlib vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -83,7 +83,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.go-version == '1.24'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         files: coverage.out
         fail_ci_if_error: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Set up Go
       uses: actions/setup-go@v6

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/tirthpatell/threads-go
 
 go 1.21
+
+toolchain go1.25.11

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -2,6 +2,8 @@ module integration
 
 go 1.21
 
+toolchain go1.25.11
+
 replace github.com/tirthpatell/threads-go => ../..
 
 require github.com/tirthpatell/threads-go v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Summary

`govulncheck` flagged **19 reachable Go standard library vulnerabilities** when building with go1.24.4 — across crypto/tls, crypto/x509, net/http, net/url, net/textproto, and encoding/asn1, reachable via `HTTPClient.executeRequest` and the examples. All are patched by go1.25.11.

- Add `toolchain go1.25.11` to `go.mod` and `tests/integration/go.mod`
- The `go 1.21` language directive is unchanged, so the minimum supported Go version for library consumers stays the same; the toolchain directive only affects builds of this module (dev/CI)

Also folds in the open dependabot bumps (closes #33, closes #32):

- `actions/checkout` v6 → v7 in `ci.yml` and `integration-tests.yml`
- `codecov/codecov-action` v6 → v7 in `ci.yml`

## Verification

- `govulncheck ./...` (main module): **No vulnerabilities found**
- `govulncheck -tags=integration ./...` (integration module): **No vulnerabilities found**
- `go vet ./...` and the full unit test suite pass under go1.25.11