### PR TITLE
chore(ci): bump setup-go v7, cache v6, dynamic-badges-action v1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
       uses: actions/checkout@v7
     
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
     
     - name: Cache Go modules
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: |
           ~/.cache/go-build
@@ -70,7 +70,7 @@ jobs:
 
     - name: Update coverage badge
       if: github.ref == 'refs/heads/main' && matrix.go-version == '1.24'
-      uses: schneegans/dynamic-badges-action@v1.8.0
+      uses: schneegans/dynamic-badges-action@v1.9.0
       with:
         auth: ${{ secrets.GIST_TOKEN }}
         gistID: 2c608589294aed9aa900256daeec0fd4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,12 +26,12 @@ jobs:
       uses: actions/checkout@v7
     
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: '1.21'
         
     - name: Cache Go modules
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: |
           ~/.cache/go-build


### PR DESCRIPTION
Consolidates the three open Dependabot bumps into one change.

| Action | From | To | Dependabot PR |
|---|---|---|---|
| `actions/setup-go` | v6 | v7 | #37 |
| `actions/cache` | v5 | v6 | #35 |
| `schneegans/dynamic-badges-action` | v1.8.0 | v1.9.0 | #36 |

Both `actions/setup-go@v7` and `actions/cache@v6` are ESM migrations plus dependency refreshes — no inputs added, removed, or renamed, so the existing `with:` blocks in `ci.yml` and `integration-tests.yml` are unchanged apart from the version pins.

Verified all three tags resolve upstream. Closes #35, closes #36, closes #37 once merged.