### PR TITLE
feat(auth): normalize OAuth token_type across all token endpoints

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -16,6 +16,9 @@ import (
 // TokenResponse represents the response from token exchange endpoint.
 // This structure is returned when exchanging an authorization code for an access token.
 // The access token can then be used to authenticate API requests.
+//
+// TokenType holds the raw wire value; use NormalizedTokenType for the
+// canonical spelling.
 type TokenResponse struct {
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
@@ -37,6 +40,25 @@ type LongLivedTokenResponse struct {
 type AppAccessTokenResponse struct {
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
+}
+
+// NormalizedTokenType returns the canonical token type for the response.
+func (r *TokenResponse) NormalizedTokenType() string { return normalizeTokenType(r.TokenType) }
+
+// NormalizedTokenType returns the canonical token type for the response.
+func (r *LongLivedTokenResponse) NormalizedTokenType() string { return normalizeTokenType(r.TokenType) }
+
+// NormalizedTokenType returns the canonical token type for the response.
+func (r *AppAccessTokenResponse) NormalizedTokenType() string { return normalizeTokenType(r.TokenType) }
+
+// normalizeTokenType canonicalizes a token_type value. The API returns it
+// lowercase and older responses omit it entirely; both become TokenTypeBearer.
+// Any other value is returned unchanged.
+func normalizeTokenType(tokenType string) string {
+	if tokenType == "" || strings.EqualFold(tokenType, TokenTypeBearer) {
+		return TokenTypeBearer
+	}
+	return tokenType
 }
 
 // generateState generates a random state parameter for OAuth security
@@ -142,7 +164,7 @@ func (c *Client) ExchangeCodeForToken(ctx context.Context, code, expectedState, 
 
 	tokenInfo := &TokenInfo{
 		AccessToken: tokenResp.AccessToken,
-		TokenType:   tokenResp.TokenType,
+		TokenType:   tokenResp.NormalizedTokenType(),
 		ExpiresAt:   expiresAt,
 		UserID:      fmt.Sprintf("%d", tokenResp.UserID),
 		CreatedAt:   now,
@@ -159,7 +181,7 @@ func (c *Client) ExchangeCodeForToken(ctx context.Context, code, expectedState, 
 	if c.config.Logger != nil {
 		c.config.Logger.Info("Successfully exchanged authorization code for access token",
 			"user_id", fmt.Sprintf("%d", tokenResp.UserID),
-			"token_type", tokenResp.TokenType,
+			"token_type", tokenResp.NormalizedTokenType(),
 			"expires_at", expiresAt)
 	}
 
@@ -219,7 +241,7 @@ func (c *Client) GetLongLivedToken(ctx context.Context) error {
 
 	tokenInfo := &TokenInfo{
 		AccessToken: tokenResp.AccessToken,
-		TokenType:   tokenResp.TokenType,
+		TokenType:   tokenResp.NormalizedTokenType(),
 		ExpiresAt:   expiresAt,
 		UserID:      userID,
 		CreatedAt:   now,
@@ -237,7 +259,7 @@ func (c *Client) GetLongLivedToken(ctx context.Context) error {
 		c.config.Logger.Info("Successfully converted to long-lived token",
 			"expires_in_seconds", tokenResp.ExpiresIn,
 			"expires_at", expiresAt,
-			"token_type", tokenResp.TokenType)
+			"token_type", tokenResp.NormalizedTokenType())
 	}
 
 	return nil
@@ -295,7 +317,7 @@ func (c *Client) RefreshToken(ctx context.Context) error {
 
 	tokenInfo := &TokenInfo{
 		AccessToken: tokenResp.AccessToken,
-		TokenType:   tokenResp.TokenType,
+		TokenType:   tokenResp.NormalizedTokenType(),
 		ExpiresAt:   expiresAt,
 		UserID:      userID,
 		CreatedAt:   now,
@@ -313,7 +335,7 @@ func (c *Client) RefreshToken(ctx context.Context) error {
 		c.config.Logger.Info("Successfully refreshed access token",
 			"expires_in_seconds", tokenResp.ExpiresIn,
 			"expires_at", expiresAt,
-			"token_type", tokenResp.TokenType)
+			"token_type", tokenResp.NormalizedTokenType())
 	}
 
 	return nil
@@ -548,7 +570,7 @@ func (c *Client) GetAppAccessToken(ctx context.Context) (*AppAccessTokenResponse
 
 	if c.config.Logger != nil {
 		c.config.Logger.Info("Successfully obtained app access token",
-			"token_type", tokenResp.TokenType)
+			"token_type", tokenResp.NormalizedTokenType())
 	}
 
 	return &tokenResp, nil
@@ -584,7 +606,7 @@ func (c *Client) SetTokenFromDebugInfo(accessToken string, debugResp *DebugToken
 
 	tokenInfo := &TokenInfo{
 		AccessToken: accessToken,
-		TokenType:   "Bearer", // Threads API uses Bearer tokens
+		TokenType:   TokenTypeBearer,
 		ExpiresAt:   expiresAt,
 		UserID:      debugResp.Data.UserID,
 		CreatedAt:   issuedAt, // Use the issued_at from the API

--- a/auth.go
+++ b/auth.go
@@ -164,7 +164,7 @@ func (c *Client) ExchangeCodeForToken(ctx context.Context, code, expectedState, 
 
 	tokenInfo := &TokenInfo{
 		AccessToken: tokenResp.AccessToken,
-		TokenType:   tokenResp.NormalizedTokenType(),
+		TokenType:   tokenResp.TokenType,
 		ExpiresAt:   expiresAt,
 		UserID:      fmt.Sprintf("%d", tokenResp.UserID),
 		CreatedAt:   now,
@@ -241,7 +241,7 @@ func (c *Client) GetLongLivedToken(ctx context.Context) error {
 
 	tokenInfo := &TokenInfo{
 		AccessToken: tokenResp.AccessToken,
-		TokenType:   tokenResp.NormalizedTokenType(),
+		TokenType:   tokenResp.TokenType,
 		ExpiresAt:   expiresAt,
 		UserID:      userID,
 		CreatedAt:   now,
@@ -317,7 +317,7 @@ func (c *Client) RefreshToken(ctx context.Context) error {
 
 	tokenInfo := &TokenInfo{
 		AccessToken: tokenResp.AccessToken,
-		TokenType:   tokenResp.NormalizedTokenType(),
+		TokenType:   tokenResp.TokenType,
 		ExpiresAt:   expiresAt,
 		UserID:      userID,
 		CreatedAt:   now,

--- a/auth_test.go
+++ b/auth_test.go
@@ -1082,3 +1082,32 @@ func TestSetTokenInfo_DoesNotMutateCaller(t *testing.T) {
 		t.Errorf("expected %q, got %q", TokenTypeBearer, got)
 	}
 }
+
+func TestNewClient_NormalizesTokenTypeFromStorage(t *testing.T) {
+	for _, stored := range []string{"", "bearer"} {
+		config := &Config{
+			ClientID:     "test-id",
+			ClientSecret: "test-secret",
+			RedirectURI:  "https://example.com/callback",
+			TokenStorage: &MemoryTokenStorage{token: &TokenInfo{
+				AccessToken: "persisted",
+				TokenType:   stored,
+				ExpiresAt:   time.Now().Add(time.Hour),
+				UserID:      "12345",
+				CreatedAt:   time.Now(),
+			}},
+		}
+		config.SetDefaults()
+
+		client, err := NewClient(config)
+		if err != nil {
+			t.Fatalf("stored %q: %v", stored, err)
+		}
+		if got := client.GetTokenInfo().TokenType; got != TokenTypeBearer {
+			t.Errorf("stored %q: GetTokenInfo gave %q, want %q", stored, got, TokenTypeBearer)
+		}
+		if got := client.GetTokenDebugInfo()["token_type"]; got != TokenTypeBearer {
+			t.Errorf("stored %q: debug info gave %q, want %q", stored, got, TokenTypeBearer)
+		}
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -968,3 +968,77 @@ func TestTokenExpiration(t *testing.T) {
 		t.Error("expected token to be expiring soon")
 	}
 }
+
+func TestNormalizeTokenType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", TokenTypeBearer},
+		{"bearer", TokenTypeBearer},
+		{"Bearer", TokenTypeBearer},
+		{"BEARER", TokenTypeBearer},
+		{"mac", "mac"},
+	}
+	for _, tc := range cases {
+		if got := normalizeTokenType(tc.in); got != tc.want {
+			t.Errorf("normalizeTokenType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestExchangeCodeForToken_TokenTypeNormalized(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"access_token":"tok","token_type":"bearer","expires_in":3600,"user_id":123}`))
+
+	if err := client.ExchangeCodeForToken(context.Background(), "code", "state", "state"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := client.GetTokenInfo().TokenType; got != TokenTypeBearer {
+		t.Errorf("expected %q, got %q", TokenTypeBearer, got)
+	}
+}
+
+func TestExchangeCodeForToken_TokenTypeDefaulted(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"access_token":"tok","expires_in":3600,"user_id":123}`))
+
+	if err := client.ExchangeCodeForToken(context.Background(), "code", "state", "state"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := client.GetTokenInfo().TokenType; got != TokenTypeBearer {
+		t.Errorf("expected %q, got %q", TokenTypeBearer, got)
+	}
+}
+
+func TestTokenResponses_NormalizedTokenType(t *testing.T) {
+	if got := (&TokenResponse{TokenType: "bearer"}).NormalizedTokenType(); got != TokenTypeBearer {
+		t.Errorf("TokenResponse: got %q", got)
+	}
+	if got := (&LongLivedTokenResponse{}).NormalizedTokenType(); got != TokenTypeBearer {
+		t.Errorf("LongLivedTokenResponse: got %q", got)
+	}
+	if got := (&AppAccessTokenResponse{TokenType: "BEARER"}).NormalizedTokenType(); got != TokenTypeBearer {
+		t.Errorf("AppAccessTokenResponse: got %q", got)
+	}
+}
+
+func TestGetLongLivedToken_TokenTypeNormalized(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"access_token":"ll","token_type":"bearer","expires_in":5184000}`))
+
+	if err := client.GetLongLivedToken(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := client.GetTokenInfo().TokenType; got != TokenTypeBearer {
+		t.Errorf("expected %q, got %q", TokenTypeBearer, got)
+	}
+}
+
+func TestRefreshToken_TokenTypeNormalized(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{"access_token":"ref","token_type":"bearer","expires_in":5184000}`))
+
+	if err := client.RefreshToken(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := client.GetTokenInfo().TokenType; got != TokenTypeBearer {
+		t.Errorf("expected %q, got %q", TokenTypeBearer, got)
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1042,3 +1042,43 @@ func TestRefreshToken_TokenTypeNormalized(t *testing.T) {
 		t.Errorf("expected %q, got %q", TokenTypeBearer, got)
 	}
 }
+
+func TestLoadTokenFromStorage_NormalizesTokenType(t *testing.T) {
+	for _, stored := range []string{"", "bearer"} {
+		client := testClient(t, jsonHandler(200, `{}`))
+		client.tokenStorage = &MemoryTokenStorage{token: &TokenInfo{
+			AccessToken: "persisted",
+			TokenType:   stored,
+			ExpiresAt:   time.Now().Add(time.Hour),
+			UserID:      "12345",
+			CreatedAt:   time.Now(),
+		}}
+
+		if err := client.LoadTokenFromStorage(); err != nil {
+			t.Fatalf("stored %q: unexpected error: %v", stored, err)
+		}
+		if got := client.GetTokenInfo().TokenType; got != TokenTypeBearer {
+			t.Errorf("stored %q: expected %q, got %q", stored, TokenTypeBearer, got)
+		}
+	}
+}
+
+func TestSetTokenInfo_DoesNotMutateCaller(t *testing.T) {
+	client := testClient(t, jsonHandler(200, `{}`))
+	caller := &TokenInfo{
+		AccessToken: "tok",
+		TokenType:   "bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		CreatedAt:   time.Now(),
+	}
+
+	if err := client.SetTokenInfo(caller); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if caller.TokenType != "bearer" {
+		t.Errorf("caller struct was mutated: TokenType = %q", caller.TokenType)
+	}
+	if got := client.GetTokenInfo().TokenType; got != TokenTypeBearer {
+		t.Errorf("expected %q, got %q", TokenTypeBearer, got)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -517,7 +517,7 @@ func NewClientWithToken(accessToken string, config *Config) (*Client, error) {
 	// Set a temporary token to enable the debug call
 	tempTokenInfo := &TokenInfo{
 		AccessToken: accessToken,
-		TokenType:   "Bearer",
+		TokenType:   TokenTypeBearer,
 		ExpiresAt:   time.Now().Add(time.Hour), // Temporary, will be updated
 		CreatedAt:   time.Now(),
 	}
@@ -559,7 +559,7 @@ func NewClientWithToken(accessToken string, config *Config) (*Client, error) {
 	// 60-day expiry (standard Threads long-lived token lifetime).
 	if err := client.SetTokenInfo(&TokenInfo{
 		AccessToken: accessToken,
-		TokenType:   "Bearer",
+		TokenType:   TokenTypeBearer,
 		ExpiresAt:   time.Now().Add(60 * 24 * time.Hour),
 		UserID:      me.ID,
 		CreatedAt:   time.Now(),

--- a/client.go
+++ b/client.go
@@ -576,14 +576,20 @@ func (c *Client) SetTokenInfo(tokenInfo *TokenInfo) error {
 		return fmt.Errorf("tokenInfo cannot be nil")
 	}
 
+	// Normalize here so every path — token endpoints, persisted tokens written
+	// by older versions, caller-supplied TokenInfo — agrees on the token type.
+	// Work on a copy to avoid mutating the caller's struct.
+	stored := *tokenInfo
+	stored.TokenType = normalizeTokenType(stored.TokenType)
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.tokenInfo = tokenInfo
-	c.accessToken = tokenInfo.AccessToken
+	c.tokenInfo = &stored
+	c.accessToken = stored.AccessToken
 
 	// Store the token using the configured storage
-	if err := c.tokenStorage.Store(tokenInfo); err != nil {
+	if err := c.tokenStorage.Store(&stored); err != nil {
 		return fmt.Errorf("failed to store token: %w", err)
 	}
 

--- a/client.go
+++ b/client.go
@@ -199,6 +199,16 @@ type TokenInfo struct {
 	CreatedAt   time.Time `json:"created_at"`
 }
 
+// normalized returns a copy with a canonical TokenType, leaving the receiver
+// untouched. Tokens reach the client from several places — the token
+// endpoints, persisted storage written by older versions, callers building
+// TokenInfo by hand — and every one of them goes through here.
+func (t *TokenInfo) normalized() *TokenInfo {
+	c := *t
+	c.TokenType = normalizeTokenType(c.TokenType)
+	return &c
+}
+
 // MemoryTokenStorage provides in-memory token storage (default)
 type MemoryTokenStorage struct {
 	token *TokenInfo
@@ -483,8 +493,9 @@ func NewClient(config *Config) (*Client, error) {
 
 	// Try to load existing token from storage
 	if tokenInfo, err := tokenStorage.Load(); err == nil {
-		client.tokenInfo = tokenInfo
-		client.accessToken = tokenInfo.AccessToken
+		stored := tokenInfo.normalized()
+		client.tokenInfo = stored
+		client.accessToken = stored.AccessToken
 	}
 
 	return client, nil
@@ -576,20 +587,16 @@ func (c *Client) SetTokenInfo(tokenInfo *TokenInfo) error {
 		return fmt.Errorf("tokenInfo cannot be nil")
 	}
 
-	// Normalize here so every path — token endpoints, persisted tokens written
-	// by older versions, caller-supplied TokenInfo — agrees on the token type.
-	// Work on a copy to avoid mutating the caller's struct.
-	stored := *tokenInfo
-	stored.TokenType = normalizeTokenType(stored.TokenType)
+	stored := tokenInfo.normalized()
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.tokenInfo = &stored
+	c.tokenInfo = stored
 	c.accessToken = stored.AccessToken
 
 	// Store the token using the configured storage
-	if err := c.tokenStorage.Store(&stored); err != nil {
+	if err := c.tokenStorage.Store(stored); err != nil {
 		return fmt.Errorf("failed to store token: %w", err)
 	}
 

--- a/constants.go
+++ b/constants.go
@@ -37,7 +37,7 @@ const (
 	MinSearchTimestamp = 1688540400 // Minimum timestamp for search queries (July 5, 2023)
 
 	// Library version
-	Version = "1.8.0"
+	Version = "1.10.0"
 
 	// HTTP client defaults
 	DefaultHTTPTimeout = 30 * time.Second // Default HTTP request timeout

--- a/constants.go
+++ b/constants.go
@@ -49,6 +49,11 @@ const (
 	BaseAPIURL = "https://graph.threads.net"
 )
 
+// Token types
+const (
+	TokenTypeBearer = "Bearer" // Canonical token_type; the API returns it lowercase
+)
+
 // Field Sets for API requests
 const (
 	// Post fields


### PR DESCRIPTION
Meta's [August 12, 2026 changelog](https://developers.facebook.com/documentation/threads/changelog/): the short-lived token response from `POST /oauth/access_token` now includes `token_type`.

The field was already plumbed through, but the value arrives lowercase (`"bearer"`) while the library hardcoded `"Bearer"` elsewhere — so `TokenInfo.TokenType` and `GetTokenDebugInfo()["token_type"]` read `""`, `"bearer"`, or `"Bearer"` depending on which endpoint minted the token.

## Changes

- `TokenTypeBearer` constant + `normalizeTokenType()` — empty and lowercase become `"Bearer"`; anything else passes through unchanged.
- Normalization happens in `(*TokenInfo).normalized()`, used by both writers of client token state (`NewClient`'s storage restore and `SetTokenInfo`), so tokens persisted by older versions are canonicalized too.
- `SetTokenInfo` stores a copy rather than the caller's pointer.
- `NormalizedTokenType()` on the three response types; the structs keep the raw wire value.
- `Version` bumped `1.8.0` → `1.10.0` — it had drifted behind tag `v1.9.4`, so `DefaultUserAgent` reported `threads-go/1.8.0` across all of v1.9.x.

Tests cover both token-type spellings across the exchange, long-lived, refresh, storage-load, and `NewClient` paths. Full suite passes, `go vet` clean.